### PR TITLE
Added support do fully disable an integration

### DIFF
--- a/config/config.json.template
+++ b/config/config.json.template
@@ -1,5 +1,6 @@
 {
     "degiro": {
+        "enabled": true,
         "credentials": {
             "username": "USERNAME",
             "password": "PASSWORD",
@@ -9,6 +10,7 @@
         "update_frequency_minutes": "How frequently the data from DeGiro should be updated. Defaults to 5 minutes"
     },
     "bitvavo": {
+        "enabled": true,
         "credentials": {
             "apikey": "BITVAVO API KEY",
             "apisecret": "BITVAVO API SECRET"

--- a/src/stonks_overwatch/config/base_config.py
+++ b/src/stonks_overwatch/config/base_config.py
@@ -12,7 +12,12 @@ class BaseConfig:
     logger = logging.getLogger("stocks_portfolio.config")
     CONFIG_PATH = Path(PROJECT_PATH) / "config" / "config.json"
 
-    def __init__(self, credentials: Optional[BaseCredentials]) -> None:
+    def __init__(
+            self,
+            credentials: Optional[BaseCredentials],
+            enabled: bool = True,
+    ) -> None:
+        self.enabled = enabled
         self.credentials = credentials
 
     def __eq__(self, value: object) -> bool:
@@ -21,7 +26,10 @@ class BaseConfig:
         return False
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(credentials={self.credentials})"
+        return f"{self.__class__.__name__}(enabled={self.enabled}, credentials={self.credentials})"
+
+    def is_enabled(self) -> bool:
+        return self.enabled
 
     @property
     @abstractmethod

--- a/src/stonks_overwatch/config/bitvavo_config.py
+++ b/src/stonks_overwatch/config/bitvavo_config.py
@@ -10,8 +10,9 @@ class BitvavoConfig(BaseConfig):
     def __init__(
             self,
             credentials: Optional[BitvavoCredentials],
+            enabled: bool = True,
     ) -> None:
-        super().__init__(credentials)
+        super().__init__(credentials, enabled)
 
     @property
     def get_credentials(self) -> BitvavoCredentials:
@@ -19,10 +20,11 @@ class BitvavoConfig(BaseConfig):
 
     @classmethod
     def from_dict(cls, data: dict) -> "BitvavoConfig":
+        enabled = data.get("enabled", True)
         credentials_data = data.get("credentials")
         credentials = BitvavoCredentials.from_dict(credentials_data) if credentials_data else None
 
-        return cls(credentials)
+        return cls(credentials, enabled)
 
     @classmethod
     def default(cls) -> "BitvavoConfig":

--- a/src/stonks_overwatch/config/config.py
+++ b/src/stonks_overwatch/config/config.py
@@ -41,13 +41,16 @@ class Config:
         return False
 
     def is_degiro_enabled(self, selected_portfolio: PortfolioId = PortfolioId.ALL) -> bool:
-        return ((DeGiroService().check_connection()
-                or (self.degiro_configuration is not None
-                and self.degiro_configuration.credentials is not None))
+        return (self.degiro_configuration.is_enabled()
+                and (DeGiroService().check_connection()
+                    or (self.degiro_configuration is not None
+                    and self.degiro_configuration.credentials is not None)
+                )
                 and selected_portfolio in [PortfolioId.ALL, PortfolioId.DEGIRO])
 
     def is_bitvavo_enabled(self, selected_portfolio: PortfolioId = PortfolioId.ALL) -> bool:
-        return (self.bitvavo_configuration is not None
+        return (self.bitvavo_configuration.is_enabled()
+                and self.bitvavo_configuration is not None
                 and self.bitvavo_configuration.credentials is not None
                 and selected_portfolio in [PortfolioId.ALL, PortfolioId.BITVAVO])
 

--- a/src/stonks_overwatch/config/degiro_config.py
+++ b/src/stonks_overwatch/config/degiro_config.py
@@ -18,9 +18,10 @@ class DegiroConfig(BaseConfig):
             self,
             credentials: Optional[DegiroCredentials],
             start_date: date,
-            update_frequency_minutes: int = DEFAULT_DEGIRO_UPDATE_FREQUENCY
+            update_frequency_minutes: int = DEFAULT_DEGIRO_UPDATE_FREQUENCY,
+            enabled: bool = True,
     ) -> None:
-        super().__init__(credentials)
+        super().__init__(credentials, enabled)
         if update_frequency_minutes < 1:
             raise ValueError("Update frequency must be at least 1 minute")
         self.start_date = start_date
@@ -36,7 +37,8 @@ class DegiroConfig(BaseConfig):
         return False
 
     def __repr__(self) -> str:
-        return (f"DegiroConfig(credentials={self.credentials}, "
+        return (f"DegiroConfig(enabled={self.enabled}, "
+                f"credentials={self.credentials}, "
                 f"start_date={self.start_date}, "
                 f"update_frequency_minutes={self.update_frequency_minutes})")
 
@@ -46,6 +48,7 @@ class DegiroConfig(BaseConfig):
 
     @classmethod
     def from_dict(cls, data: dict) -> "DegiroConfig":
+        enabled = data.get("enabled", True)
         credentials_data = data.get("credentials")
         credentials = DegiroCredentials.from_dict(credentials_data) if credentials_data else None
         start_date = data.get("start_date", cls.DEFAULT_DEGIRO_START_DATE)
@@ -53,7 +56,7 @@ class DegiroConfig(BaseConfig):
             start_date = LocalizationUtility.convert_string_to_date(start_date)
         update_frequency_minutes = data.get("update_frequency_minutes", cls.DEFAULT_DEGIRO_UPDATE_FREQUENCY)
 
-        return cls(credentials, start_date, update_frequency_minutes)
+        return cls(credentials, start_date, update_frequency_minutes, enabled)
 
     @classmethod
     def default(cls) -> "DegiroConfig":

--- a/src/stonks_overwatch/services/bitvavo/portfolio.py
+++ b/src/stonks_overwatch/services/bitvavo/portfolio.py
@@ -243,20 +243,11 @@ class PortfolioService:
         Creates product quotations based on portfolio data and product information.
         """
         product_growth = self.calculate_product_growth()
-        tradable_products = {}
+        tradeable_products = {}
 
         for key, data in product_growth.items():
-            # product = ProductInfoRepository.get_product_info_from_id(key)
 
             data["productId"] = key
-    #         data["product"] = {
-    #             "name": product["name"],
-    #             "isin": product["isin"],
-    #             "symbol": product["symbol"],
-    #             "currency": product["currency"],
-    #             "vwdId": product["vwdId"],
-    #             "vwdIdSecondary": product["vwdIdSecondary"],
-    #         }
 
             product_history_dates = list(data["history"].keys())
 
@@ -274,14 +265,13 @@ class PortfolioService:
 
             data["quotation"] = {
                 "fromDate": product_history_dates[0],
-                # FIXME: This should be the last date of the product history
-                "toDate": LocalizationUtility.format_date_from_date(datetime.today()),
+                "toDate": product_history_dates[-1],
                 "interval": DateTimeUtility.calculate_interval(product_history_dates[0]),
                 "quotes": quotes,
             }
-            tradable_products[key] = data
+            tradeable_products[key] = data
 
-        return tradable_products
+        return tradeable_products
 
     @staticmethod
     def _is_weekend(date_str: str):

--- a/src/stonks_overwatch/views/dashboard.py
+++ b/src/stonks_overwatch/views/dashboard.py
@@ -92,7 +92,7 @@ class Dashboard(View):
         }
 
     @staticmethod
-    def __filter_dashboard_values(data_values: list[dict], start_date: str) -> list[dict]:
+    def __filter_dashboard_values(data_values: List[DailyValue], start_date: str) -> List[DailyValue]:
         # Ensure the list is sorted by date
         data_values.sort(key=lambda item: item['x'])
 


### PR DESCRIPTION
There are situation where we may want to disable an integration. Maybe due to external issues or to test something with fewer values.

Now all the integrations support a new `enabled` flag (true by default)