### PR TITLE
Revert "deps: bump luxon from 3.6.1 to 3.7.0 in /src (#121)"

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -13,7 +13,7 @@
                 "chartjs-adapter-luxon": "^1.3.1",
                 "chartjs-plugin-zoom": "^2.2.0",
                 "jquery": "^3.7.1",
-                "luxon": "^3.7.0"
+                "luxon": "^3.6.1"
             }
         },
         "node_modules/@kurkle/color": {
@@ -144,9 +144,9 @@
             "license": "MIT"
         },
         "node_modules/luxon": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.0.tgz",
-            "integrity": "sha512-FWOR5aRqol+wq5WqqCj/zQ4sHIq48T0RdeNHH0oYRRY+Ds11SOSZQ89y11TyhiQ5BLZGJorlcxi4FxgBx0LNtw==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+            "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"

--- a/src/package.json
+++ b/src/package.json
@@ -8,6 +8,6 @@
         "chartjs-adapter-luxon": "^1.3.1",
         "chartjs-plugin-zoom": "^2.2.0",
         "jquery": "^3.7.1",
-        "luxon": "^3.7.0"
+        "luxon": "^3.6.1"
     }
 }


### PR DESCRIPTION
This reverts commit 222b09d9bf3bcfa47af3a370fbf61455ab13d9cc.

The upgrade to Luxon 3.7.0 breaks the compatibility with chartjs-adapter-luxon