### PR TITLE
GitHub Actions: Fixed precommit-autoupdate

### DIFF
--- a/.github/workflows/precommit-autoupdate.yml
+++ b/.github/workflows/precommit-autoupdate.yml
@@ -17,10 +17,22 @@ jobs:
         run: pip install pre-commit
       - name: Run pre-commit autoupdate script
         run: bash .github/scripts/update_precommit_hooks.sh
+      - name: Check for changes
+        id: verify-changed-files
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Create or checkout pre-commit-autoupdate branch
+        if: steps.verify-changed-files.outputs.changed == 'true'
+        run: |
+          git checkout -b pre-commit-autoupdate || git checkout pre-commit-autoupdate
+          git reset --hard origin/main
       - name: Push changes
+        if: steps.verify-changed-files.outputs.changed == 'true'
         uses: stefanzweifel/git-auto-commit-action@v6
         with:
           commit_message: 'chore: autoupdate pre-commit hooks'
-          branch: pre-commit-autoupdate
-          create_branch: true
           push_options: '--force'


### PR DESCRIPTION
With version 6, the `create_branch` parameter doesn't work anymore. That requires to do those steps manually