### PR TITLE
fix: Standardize CHANGELOG.md copy

### DIFF
--- a/src/stonks_overwatch/app/dialogs/dialogs.py
+++ b/src/stonks_overwatch/app/dialogs/dialogs.py
@@ -113,7 +113,7 @@ class DialogManager:
         dialog.on_close = on_close
         dialog.show()
 
-    async def release_notes(self):
+    async def release_notes(self, base_url: str):
         """Show the Release Notes dialog."""
         if DialogManager._release_notes_window_instance is not None:
             self.logger.debug("Release Notes already open, focusing window.")
@@ -121,7 +121,7 @@ class DialogManager:
             DialogManager._release_notes_window_instance.show()
             return
 
-        dialog = ReleaseNotesDialog(app=self.app)
+        dialog = ReleaseNotesDialog("Release Notes", base_url, app=self.app)
         DialogManager._release_notes_window_instance = dialog
 
         def on_close(widget):

--- a/src/stonks_overwatch/app/dialogs/release_notes_dialog.py
+++ b/src/stonks_overwatch/app/dialogs/release_notes_dialog.py
@@ -1,119 +1,21 @@
-import os.path
-from pathlib import Path
-
-import markdown
 import toga
-from toga.style import Pack
-from toga.style.pack import COLUMN
 
 from stonks_overwatch.app.utils.dialog_utils import center_window_on_parent
 from stonks_overwatch.utils.core.logger import StonksLogger
 
 
 class ReleaseNotesDialog(toga.Window):
-    def __init__(self, title="Release Notes", app: toga.App | None = None):
+    def __init__(self, title: str, base_url: str, app: toga.App | None = None):
         super().__init__(title=title, minimizable=False, closable=True, size=(600, 500))
         self._app = app
         self._main_window = app.main_window
 
         self.logger = StonksLogger.get_logger("stonks_overwatch.app", "[RELEASE_NOTES]")
 
-        self.web_view = toga.WebView(style=Pack(flex=1))
-        self.web_view.content = self._convert_md_to_html()
-
-        box = toga.Box(children=[self.web_view], style=Pack(direction=COLUMN, margin=5))
-
-        self.content = box
-
-    def _convert_md_to_html(self) -> str:
-        """Convert markdown file to HTML."""
-        input_file = os.path.join(Path(self._app.paths.app).parent.parent, "CHANGELOG.md")
-
-        input_path = Path(input_file)
-        if not input_path.exists():
-            raise FileNotFoundError(f"Input file {input_file} not found")
-
-        # Read and convert
-        with open(input_path, "r", encoding="utf-8") as f:
-            lines = f.readlines()
-
-        # Replace CHANGELOG starting lines with "Release Notes" header
-        start_idx = next((i for i, line in enumerate(lines) if line.strip().startswith("##")), 0)
-        markdown_content = "# Release Notes\n" + "".join(lines[start_idx:])
-
-        html_fragment = markdown.markdown(
-            markdown_content,
-            extensions=[
-                "fenced_code",
-            ],
-            output_format="html",
-        )
-
-        # Theme colors via CSS variables
         is_dark_mode = getattr(self._app, "dark_mode", True) is True
-        if is_dark_mode:
-            bg_color = "#3B3B3B"
-            text_color = "#FFFFFF"
-            code_bg = "#696969"
-            blockquote_bg = "#101010"
-        else:
-            bg_color = "#FFFFFF"
-            text_color = "#000000"
-            code_bg = "#F5F5F5"
-            blockquote_bg = "#F0F0F0"
 
-        styled_html = f"""<!DOCTYPE html>
-<html lang=\"en\">
-<head>
-<meta charset=\"utf-8\" />
-<title>Release Notes</title>
-<meta name=\"color-scheme\" content=\"dark light\" />
-<style>
-    :root {{
-        --bg-color: {bg_color};
-        --text-color: {text_color};
-        --code-bg: {code_bg};
-        --blockquote-bg: {blockquote_bg};
-    }}
-    body {{
-        background:var(--bg-color); color:var(--text-color);
-        font-family:-apple-system, system-ui, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
-            'Open Sans', 'Helvetica Neue', sans-serif;
-        line-height:1.5; padding:1rem 1.25rem 2rem; font-size:15px;
-    }}
-    h1,h2,h3,h4,h5,h6 {{
-        color:var(--text-color);
-        font-weight:600; line-height:1.25; margin-top:1.6em; margin-bottom:0.6em;
-    }}
-    h1 {{ font-size:1.9em; }} h2 {{ font-size:1.5em; }} h3 {{ font-size:1.25em; }}
-    p {{ margin:0.6em 0 0.9em; }}
-    a {{ color:#4ea3ff; text-decoration:none; }} a:hover {{ text-decoration:underline; }}
-    hr {{ border:0; border-top:1px solid #333; margin:1.8em 0; }}
-    ul,ol {{ padding-left:1.3rem; margin:0.4em 0 1em; }} li {{ margin:0.25em 0; }}
-    code {{
-        background:var(--code-bg); color:var(--text-color); padding:0.15em 0.4em; border-radius:4px; font-size:0.95em;
-    }}
-    pre code {{ padding:0; background:transparent; }}
-    pre {{
-        background:var(--code-bg); padding:0.85rem 1rem; border-radius:6px; overflow-x:auto;
-        font-size:0.9em; line-height:1.4; border:1px solid #222;
-    }}
-    blockquote {{
-        margin:0.9rem 0; padding:0.55rem 0.9rem; border-left:4px solid #444; background:var(--blockquote-bg);
-        color:#ccc; border-radius:4px;
-    }}
-    img {{ max-width:100%; display:block; margin:0.75rem auto; }}
-    strong {{ color:var(--text-color); }} em {{ color:#ddd; }}
-</style>
-<script>
-document.addEventListener('contextmenu', event => event.preventDefault());
-</script>
-</head>
-<body>
-{html_fragment}
-</body>
-</html>"""
-        return styled_html
+        self.content = toga.WebView()
+        self.content.url = f"{base_url}/release_notes?dark_mode={is_dark_mode}"
 
     def show(self):
         center_window_on_parent(self, self._main_window)

--- a/src/stonks_overwatch/app/ui/menu.py
+++ b/src/stonks_overwatch/app/ui/menu.py
@@ -164,7 +164,9 @@ class MenuManager:
         await self.app.dialog_manager.check_for_updates()
 
     async def _release_notes_info(self, widget):
-        await self.app.dialog_manager.release_notes()
+        parsed_url = urlparse(self.app.web_view.url)
+        base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+        await self.app.dialog_manager.release_notes(base_url)
 
     def _show_logs(self, widget):
         # If the log window does not exist, create it

--- a/src/stonks_overwatch/middleware/degiro_auth.py
+++ b/src/stonks_overwatch/middleware/degiro_auth.py
@@ -10,7 +10,7 @@ from stonks_overwatch.utils.core.logger import StonksLogger
 
 
 class DeGiroAuthMiddleware:
-    PUBLIC_URLS = {"login", "expired"}
+    PUBLIC_URLS = {"login", "expired", "release_notes"}
 
     logger = StonksLogger.get_logger("stonks_overwatch.degiro_auth", "[DEGIRO|AUTH_MIDDLEWARE]")
 

--- a/src/stonks_overwatch/settings.py
+++ b/src/stonks_overwatch/settings.py
@@ -186,6 +186,7 @@ STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
     "django_node_assets.finders.NodeModulesFinder",
     "django_node_assets.finders.ManifestNodeModulesFinder",
+    "stonks_overwatch.utils.staticfiles_extra_finder.ExtraFilesFinder",
 ]
 
 NODE_PACKAGE_JSON = os.path.join(PROJECT_PATH, "src", "package.json")

--- a/src/stonks_overwatch/templates/expired.html
+++ b/src/stonks_overwatch/templates/expired.html
@@ -46,6 +46,9 @@
         }
     </style>
     {% endif %}
+    <script>
+        document.addEventListener('contextmenu', event => event.preventDefault());
+    </script>
 </head>
 <body class="min-vh-100 d-flex align-items-center justify-content-center">
     <div class="container">
@@ -117,13 +120,5 @@
             </div>
         </div>
     </div>
-
-    <script>
-        // Prevent back navigation
-        history.pushState(null, null, location.href);
-        window.onpopstate = function () {
-            history.go(1);
-        };
-    </script>
 </body>
 </html>

--- a/src/stonks_overwatch/templates/release_notes.html
+++ b/src/stonks_overwatch/templates/release_notes.html
@@ -1,0 +1,52 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Release Notes</title>
+    <link rel="icon" type="image/png" href="{% static 'stonks_overwatch-32x32.png' %}" sizes="32x32">
+    <style>
+        :root {
+            --bg-color: {{ bg_color }};
+            --text-color: {{ text_color }};
+            --code-bg: {{ code_bg }};
+            --blockquote-bg: {{  blockquote_bg }};
+        }
+        body {
+            background:var(--bg-color); color:var(--text-color);
+            font-family:-apple-system, system-ui, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
+                'Open Sans', 'Helvetica Neue', sans-serif;
+            line-height:1.5; padding:1rem 1.25rem 2rem; font-size:15px;
+        }
+        h1,h2,h3,h4,h5,h6 {
+            color:var(--text-color);
+        }
+        p { margin:0.6em 0 0.9em; }
+        a { color:#4ea3ff; text-decoration:none; } a:hover { text-decoration:underline; }
+        hr { border:0; border-top:1px solid #333; margin:1.8em 0; }
+        ul,ol { padding-left:1.3rem; margin:0.4em 0 1em; } li { margin:0.25em 0; }
+        code {
+            background:var(--code-bg); color:var(--text-color); padding:0.15em 0.4em; border-radius:4px; font-size:0.95em;
+        }
+        pre code { padding:0; background:transparent; }
+        pre {
+            background:var(--code-bg); padding:0.85rem 1rem; border-radius:6px; overflow-x:auto;
+            font-size:0.9em; line-height:1.4; border:1px solid #222;
+        }
+        blockquote {
+            margin:0.9rem 0; padding:0.55rem 0.9rem; border-left:4px solid #444; background:var(--blockquote-bg);
+            color:#ccc; border-radius:4px;
+        }
+        img { max-width:100%; display:block; margin:0.75rem auto; }
+        strong { color:var(--text-color); } em { color:#ddd; }
+    </style>
+    <script>
+        document.addEventListener('contextmenu', event => event.preventDefault());
+    </script>
+</head>
+<body class="min-vh-100">
+    {{ html_fragment|safe }}
+</body>
+</html>

--- a/src/stonks_overwatch/urls.py
+++ b/src/stonks_overwatch/urls.py
@@ -31,6 +31,7 @@ from stonks_overwatch.views.expired import ExpiredView
 from stonks_overwatch.views.fees import Fees
 from stonks_overwatch.views.login import Login
 from stonks_overwatch.views.portfolio import Portfolio
+from stonks_overwatch.views.release_notes import ReleaseNotesView
 from stonks_overwatch.views.static import RootStaticFileView
 from stonks_overwatch.views.transactions import Transactions
 
@@ -47,6 +48,7 @@ urlpatterns = [
     path("transactions", Transactions.as_view(), name="transactions"),
     path("configuration", ConfigurationView.as_view(), name="configuration"),
     path("expired", ExpiredView.as_view(), name="expired"),
+    path("release_notes", ReleaseNotesView.as_view(), name="release_notes"),
     path("assets/<str:product_type>/<str:symbol>", AssetLogoView.as_view(), name="asset_logo"),
     re_path(r"^(favicon\.ico|apple-touch-icon\.png|apple-touch-icon-precomposed\.png)$", RootStaticFileView.as_view()),
 ]

--- a/src/stonks_overwatch/utils/staticfiles_extra_finder.py
+++ b/src/stonks_overwatch/utils/staticfiles_extra_finder.py
@@ -1,0 +1,31 @@
+import os
+
+from django.conf import settings
+from django.contrib.staticfiles.finders import BaseFinder
+from django.contrib.staticfiles.storage import StaticFilesStorage
+
+
+class ExtraFilesFinder(BaseFinder):
+    """
+    Custom staticfiles finder to expose CHANGELOG.md, LICENSE, and THIRD_PARTY_LICENSES.txt
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.files = [
+            os.path.join(settings.PROJECT_PATH, "CHANGELOG.md"),
+            os.path.join(settings.PROJECT_PATH, "LICENSE"),
+            os.path.join(settings.PROJECT_PATH, "THIRD_PARTY_LICENSES.txt"),
+        ]
+        self.storage = StaticFilesStorage(location=settings.PROJECT_PATH)
+
+    def find(self, path, all=False):
+        for file_path in self.files:
+            if os.path.basename(file_path) == path:
+                return file_path if not all else [file_path]
+        return [] if all else None
+
+    def list(self, ignore_patterns):
+        for file_path in self.files:
+            if os.path.exists(file_path):
+                yield (os.path.basename(file_path), self.storage)

--- a/src/stonks_overwatch/views/release_notes.py
+++ b/src/stonks_overwatch/views/release_notes.py
@@ -1,0 +1,50 @@
+import os
+
+import markdown
+from django.conf import settings
+from django.shortcuts import render
+from django.views import View
+
+
+class ReleaseNotesView(View):
+    def get(self, request):
+        changelog_path = os.path.join(settings.STATIC_ROOT, "CHANGELOG.md")
+        # Read and convert
+        with open(changelog_path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+
+        # Replace CHANGELOG starting lines with "Release Notes" header
+        start_idx = next((i for i, line in enumerate(lines) if line.strip().startswith("##")), 0)
+        markdown_content = "# Release Notes\n" + "".join(lines[start_idx:])
+
+        html_fragment = markdown.markdown(
+            markdown_content,
+            extensions=[
+                "fenced_code",
+            ],
+            output_format="html",
+        )
+
+        dark_mode_param = request.GET.get("dark_mode", "0")
+        is_dark_mode = dark_mode_param in ["1", "true", "True"]
+
+        if is_dark_mode:
+            bg_color = "#3B3B3B"
+            text_color = "#FFFFFF"
+            code_bg = "#696969"
+            blockquote_bg = "#101010"
+        else:
+            bg_color = "#FFFFFF"
+            text_color = "#000000"
+            code_bg = "#F5F5F5"
+            blockquote_bg = "#F0F0F0"
+
+        context = {
+            "html_fragment": html_fragment,
+            "bg_color": bg_color,
+            "text_color": text_color,
+            "code_bg": code_bg,
+            "blockquote_bg": blockquote_bg,
+        }
+
+        return render(request, "release_notes.html", context)


### PR DESCRIPTION
Instead of having special code in Briefcase, this PR copies the `CHANGELOG.md`, `LICENSE` and `THIRD_PARTY_LICENSE.txt` as part of the static files, simplifying the code.

The CHANGELOG is now published as a URL, allowing for better support and alignment with the rest of the code, like the 'Expired License'