### PR TITLE
fix: Fixed Dividends screen resize

### DIFF
--- a/src/stonks_overwatch/templates/dividends.html
+++ b/src/stonks_overwatch/templates/dividends.html
@@ -29,7 +29,7 @@
                 </div>
             </div>
         </div>
-        <div id="chart-container" style="position: relative; width: 100%; height: 25vh;">
+        <div class="row w-100" style="position: relative; width: 100%; height: 25vh;">
             <canvas id="dividends-growth"></canvas>
         </div>
     </div>


### PR DESCRIPTION
When collapsing/expanding the sidebar, the Dividends screen was not being resized properly