### PR TITLE
fix: Fixed race condition in the login screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ _This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 
+- **Login:**
+    - Fixed race condition in the login screen. After introducing the credentials, the "2FA" screen could stay stuck or the "Loading" screen may not be shown
 - **Native Application:**
     - Application Settings were not being shown correctly in some cases
 

--- a/src/stonks_overwatch/templates/login.html
+++ b/src/stonks_overwatch/templates/login.html
@@ -103,8 +103,10 @@
                     <input type="hidden" name="update_portfolio" id="update_portfolio" value="true">
                     <script>
                         $(document).ready(function() {
-                            <!-- In this scenario we want to submit the form automatically -->
-                            document.getElementById("login-form").submit();
+                            // Small delay to ensure loading screen is visible before form submission
+                            setTimeout(function() {
+                                document.getElementById("login-form").submit();
+                            }, 100);
                         });
                     </script>
                 {% else %}

--- a/src/stonks_overwatch/views/login.py
+++ b/src/stonks_overwatch/views/login.py
@@ -46,13 +46,18 @@ class Login(View):
 
     def get(self, request: HttpRequest) -> HttpResponse:
         # Use AuthenticationService to check TOTP requirement, in-app auth requirement, and authentication status
-        show_otp = self.auth_service.session_manager.is_totp_required(request)
-        show_in_app_auth = self.auth_service.session_manager.is_in_app_auth_required(request)
+        show_otp = False
+        show_in_app_auth = False
         show_loading = False
 
+        # If user is already authenticated, show loading screen and skip TOTP/in-app auth checks
         if self.auth_service.is_user_authenticated(request):
             self.logger.info(LogMessages.USER_ALREADY_AUTHENTICATED)
             show_loading = True
+        else:
+            # Only check for TOTP/in-app auth requirements if user is not authenticated
+            show_otp = self.auth_service.session_manager.is_totp_required(request)
+            show_in_app_auth = self.auth_service.session_manager.is_in_app_auth_required(request)
 
         return self._render_login_template(request, show_otp, show_loading, show_in_app_auth)
 


### PR DESCRIPTION
# Pull Request

## Description

When login, after introducing the credentials, the "2FA" screen could stay stuck or the "Loading" screen may not be shown

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactoring
- [ ] 🏦 Broker integration
- [ ] 🎨 UI/UX

## Testing & Quality

- [x] Tests pass (`make test`)
- [x] Code formatted (`make lint-fix`)
- [ ] Documentation updated

---

✅ **Checklist:** Read [CONTRIBUTING](../CONTRIBUTING.md), tests pass, code formatted, docs updated

**Thank you for contributing!** 🎉
