### PR TITLE
fix: Cosmetic fix to the TOTP progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ _This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) a
     - Fixed race condition in the login screen. After introducing the credentials, the "2FA" screen could stay stuck or the "Loading" screen may not be shown
 - **Native Application:**
     - Application Settings were not being shown correctly in some cases
+- **Settings:**
+    - Cosmetic fix to the TOTP progress bar
 
 ### Security
 

--- a/src/stonks_overwatch/templates/components/brokers/degiro_settings.html
+++ b/src/stonks_overwatch/templates/components/brokers/degiro_settings.html
@@ -47,9 +47,9 @@
         <div class="verification-code-container">
             <span class="verification-code" id="degiro-verification-code"></span>
             <div class="circular-progress-container">
-                <svg class="circular-progress" viewBox="0 0 36 36">
-                    <circle class="circular-progress-background" cx="18" cy="18" r="16"></circle>
-                    <circle class="circular-progress-bar" id="degiro-verification-timer" cx="18" cy="18" r="16"></circle>
+                <svg class="circular-progress" viewBox="0 0 40 40">
+                    <circle class="circular-progress-background" cx="20" cy="20" r="16"></circle>
+                    <circle class="circular-progress-bar" id="degiro-verification-timer" cx="20" cy="20" r="16"></circle>
                 </svg>
             </div>
         </div>


### PR DESCRIPTION
# Pull Request

## Description

The TOTP progress bar view box was too small, making some of the sides look like a square

## Type

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactoring
- [ ] 🏦 Broker integration
- [x] 🎨 UI/UX

## Testing & Quality

- [x] Tests pass (`make test`)
- [x] Code formatted (`make lint-fix`)
- [ ] Documentation updated

---

✅ **Checklist:** Read [CONTRIBUTING](../CONTRIBUTING.md), tests pass, code formatted, docs updated

**Thank you for contributing!** 🎉
