### PR TITLE
refactor: replace hardcoded broker strings with BrokerName enum

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,31 @@ make collectstatic     # After editing static files
 - ❌ Don't use bare `except:` - Always catch specific exceptions
 - ❌ Don't hardcode paths - Use environment variables or Django settings
 - ❌ Don't use HTML in Markdown files - Use pure Markdown syntax only
+- ❌ Don't run `python` directly - Use `poetry run python` or `make` commands
+
+### 🐍 Python Execution
+
+**CRITICAL:** This project uses Poetry for dependency management. Always use Poetry to run Python commands:
+
+- ✅ **CORRECT:** `poetry run python script.py`
+- ✅ **CORRECT:** `make test` (uses Poetry internally)
+- ✅ **CORRECT:** `make lint-fix` (uses Poetry internally)
+- ❌ **WRONG:** `python script.py` (may use wrong Python version or missing dependencies)
+- ❌ **WRONG:** `python3 script.py` (bypasses Poetry environment)
+
+**Why Poetry?**
+- Ensures correct Python version (3.13+)
+- Activates virtual environment with all dependencies
+- Maintains consistent environment across development and CI/CD
+
+**Common Commands:**
+```bash
+poetry run python manage.py <command>  # Run Django management commands
+poetry run pytest                       # Run tests directly
+poetry shell                            # Activate Poetry shell for interactive work
+```
+
+**Best Practice:** Use `make` commands when available, as they handle Poetry automatically.
 
 ---
 

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -12,6 +12,7 @@ import textwrap
 from argparse import Namespace
 
 from scripts.common import setup_script_environment
+from stonks_overwatch.constants import BrokerName
 
 # Set up Django environment and logging
 setup_script_environment()
@@ -174,22 +175,22 @@ def bitvavo_transactions(update_service: BitvavoUpdateService) -> None:
 
 
 def get_degiro_update_service(args, broker_factory):
-    degiro_import_folder = os.path.join(args.import_folder, "degiro")
-    degiro_config = broker_factory.create_config("degiro")
+    degiro_import_folder = os.path.join(args.import_folder, BrokerName.DEGIRO.lower())
+    degiro_config = broker_factory.create_config(BrokerName.DEGIRO)
     return DegiroUpdateService(
         import_folder=degiro_import_folder, debug_mode=args.debug, config=degiro_config, force_connect=True
     )
 
 
 def get_ibkr_update_service(args, broker_factory):
-    ibkr_import_folder = os.path.join(args.import_folder, "ibkr")
-    ibkr_config = broker_factory.create_config("ibkr")
+    ibkr_import_folder = os.path.join(args.import_folder, BrokerName.IBKR.lower())
+    ibkr_config = broker_factory.create_config(BrokerName.IBKR)
     return IbkrUpdateService(import_folder=ibkr_import_folder, debug_mode=args.debug, config=ibkr_config)
 
 
 def get_bitvavo_update_service(args, broker_factory):
-    bitvavo_import_folder = os.path.join(args.import_folder, "bitvavo")
-    bitvavo_config = broker_factory.create_config("bitvavo")
+    bitvavo_import_folder = os.path.join(args.import_folder, BrokerName.BITVAVO.lower())
+    bitvavo_config = broker_factory.create_config(BrokerName.BITVAVO)
     return BitvavoUpdateService(import_folder=bitvavo_import_folder, debug_mode=args.debug, config=bitvavo_config)
 
 

--- a/src/stonks_overwatch/config/bitvavo.py
+++ b/src/stonks_overwatch/config/bitvavo.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional
 
 from stonks_overwatch.config.base_config import BaseConfig
 from stonks_overwatch.config.base_credentials import BaseCredentials
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.utils.core.localization import LocalizationUtility
 
 
@@ -31,7 +32,7 @@ class BitvavoCredentials(BaseCredentials):
 
 
 class BitvavoConfig(BaseConfig):
-    config_key = "bitvavo"
+    config_key = BrokerName.BITVAVO.value
     DEFAULT_BITVAVO_UPDATE_FREQUENCY = 5
     DEFAULT_BITVAVO_START_DATE_STR = "2020-01-01"
     DEFAULT_BITVAVO_START_DATE = LocalizationUtility.convert_string_to_date(DEFAULT_BITVAVO_START_DATE_STR)
@@ -90,7 +91,7 @@ class BitvavoConfig(BaseConfig):
     @classmethod
     def default(cls) -> "BitvavoConfig":
         try:
-            return cls.from_db_with_json_override("bitvavo")
+            return cls.from_db_with_json_override(BrokerName.BITVAVO)
         except Exception:
             cls.logger.debug("Cannot find BITVAVO configuration file. Using default values")
             return BitvavoConfig(

--- a/src/stonks_overwatch/config/config.py
+++ b/src/stonks_overwatch/config/config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 from stonks_overwatch.config.base_config import BaseConfig
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.core.factories.broker_factory import BrokerFactory
 from stonks_overwatch.services.models import PortfolioId
 from stonks_overwatch.utils.core.logger import StonksLogger
@@ -34,7 +35,7 @@ class Config:
         self.base_currency = base_currency or self.DEFAULT_BASE_CURRENCY
         self._factory = BrokerFactory()
 
-    def get_broker_config(self, broker_name: str) -> Optional[BaseConfig]:
+    def get_broker_config(self, broker_name: BrokerName) -> Optional[BaseConfig]:
         """
         Get a broker configuration using unified BrokerFactory.
 
@@ -67,7 +68,7 @@ class Config:
         except (AttributeError, TypeError):
             return False
 
-    def _is_broker_enabled(self, broker_name: str) -> bool:
+    def _is_broker_enabled(self, broker_name: BrokerName) -> bool:
         """
         Check if a specific broker is enabled.
 

--- a/src/stonks_overwatch/config/degiro.py
+++ b/src/stonks_overwatch/config/degiro.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional
 
 from stonks_overwatch.config.base_config import BaseConfig
 from stonks_overwatch.config.base_credentials import BaseCredentials
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.utils.core.localization import LocalizationUtility
 
 
@@ -34,7 +35,7 @@ class DegiroCredentials(BaseCredentials):
 
 
 class DegiroConfig(BaseConfig):
-    config_key = "degiro"
+    config_key = BrokerName.DEGIRO.value
     DEFAULT_DEGIRO_UPDATE_FREQUENCY = 5
     DEFAULT_DEGIRO_START_DATE_STR = "2020-01-01"
     DEFAULT_DEGIRO_START_DATE = LocalizationUtility.convert_string_to_date(DEFAULT_DEGIRO_START_DATE_STR)
@@ -93,7 +94,7 @@ class DegiroConfig(BaseConfig):
     @classmethod
     def default(cls) -> "DegiroConfig":
         try:
-            return cls.from_db_with_json_override("degiro")
+            return cls.from_db_with_json_override(BrokerName.DEGIRO)
         except Exception:
             cls.logger.debug("Cannot find DEGIRO configuration file. Using default values")
             return DegiroConfig(

--- a/src/stonks_overwatch/config/ibkr.py
+++ b/src/stonks_overwatch/config/ibkr.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional
 
 from stonks_overwatch.config.base_config import BaseConfig
 from stonks_overwatch.config.base_credentials import BaseCredentials
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.utils.core.localization import LocalizationUtility
 
 
@@ -98,7 +99,7 @@ class IbkrCredentials(BaseCredentials):
 
 
 class IbkrConfig(BaseConfig):
-    config_key = "ibkr"
+    config_key = BrokerName.IBKR.value
     # As per https://www.interactivebrokers.com/campus/ibkr-api-page/cpapi-v1/#pacing-limitations
     # Some endpoints have a limit of 15 requests per minute: ie: /pa/transactions
     DEFAULT_IBKR_UPDATE_FREQUENCY = 15
@@ -159,7 +160,7 @@ class IbkrConfig(BaseConfig):
     @classmethod
     def default(cls) -> "IbkrConfig":
         try:
-            return cls.from_db_with_json_override("ibkr")
+            return cls.from_db_with_json_override(BrokerName.IBKR)
         except Exception:
             cls.logger.debug("Cannot find IBKR configuration file. Using default values")
             return IbkrConfig(

--- a/src/stonks_overwatch/constants/__init__.py
+++ b/src/stonks_overwatch/constants/__init__.py
@@ -1,0 +1,5 @@
+"""Constants package for Stonks Overwatch."""
+
+from stonks_overwatch.constants.brokers import BrokerName
+
+__all__ = ["BrokerName"]

--- a/src/stonks_overwatch/constants/brokers.py
+++ b/src/stonks_overwatch/constants/brokers.py
@@ -1,0 +1,191 @@
+"""Broker name constants for type-safe broker identification."""
+
+from enum import Enum, unique
+from typing import List, Union
+
+
+@unique
+class BrokerName(str, Enum):
+    """Standardized broker name constants with display metadata.
+
+    This enum provides type-safe broker name constants to:
+    - Eliminate typo bugs from hardcoded strings
+    - Improve IDE autocomplete support
+    - Enable better type safety with type hints
+    - Provide helper methods for common operations
+    - Provide display names for UI rendering
+    - Guarantee no duplicate values (@unique decorator)
+
+    Each broker has:
+    - value: Technical identifier (e.g., "degiro")
+    - short_name: Compact display name (e.g., "IBKR")
+    - long_name: Full display name (e.g., "Interactive Brokers")
+    - display_name: Alias for long_name (primary display name)
+
+    Since this enum inherits from str, it can be used directly where strings
+    are expected, but for explicit string conversion use .value attribute.
+
+    The @unique decorator ensures no duplicate broker values can be defined,
+    preventing configuration errors at import time.
+
+    Example:
+        >>> if broker_name == BrokerName.DEGIRO:
+        >>>     # Type-safe comparison
+        >>>     pass
+        >>>
+        >>> # Get display names
+        >>> broker = BrokerName.IBKR
+        >>> broker.value           # "ibkr"
+        >>> broker.short_name      # "IBKR"
+        >>> broker.long_name       # "Interactive Brokers"
+        >>> broker.display_name    # "Interactive Brokers"
+        >>>
+        >>> # Debugging representation
+        >>> repr(BrokerName.IBKR)  # "BrokerName.IBKR"
+        >>>
+        >>> # Normalize string to enum
+        >>> broker = BrokerName.from_string("degiro")
+    """
+
+    DEGIRO = "degiro"
+    BITVAVO = "bitvavo"
+    IBKR = "ibkr"
+
+    @property
+    def short_name(self) -> str:
+        """Get the short display name for compact UI contexts.
+
+        Returns:
+            Short name suitable for buttons, tabs, labels
+
+        Example:
+            >>> BrokerName.IBKR.short_name
+            'IBKR'
+        """
+        _short_names = {
+            BrokerName.DEGIRO: "DEGIRO",
+            BrokerName.BITVAVO: "Bitvavo",
+            BrokerName.IBKR: "IBKR",
+        }
+        return _short_names.get(self, self.value.upper())
+
+    @property
+    def long_name(self) -> str:
+        """Get the full display name for descriptive UI contexts.
+
+        Returns:
+            Full official name of the broker
+
+        Example:
+            >>> BrokerName.IBKR.long_name
+            'Interactive Brokers'
+        """
+        _long_names = {
+            BrokerName.DEGIRO: "DEGIRO",
+            BrokerName.BITVAVO: "Bitvavo",
+            BrokerName.IBKR: "Interactive Brokers",
+        }
+        return _long_names.get(self, self.value.title())
+
+    @property
+    def display_name(self) -> str:
+        """Alias for long_name - the primary display name.
+
+        Returns:
+            Full display name (same as long_name)
+
+        Example:
+            >>> BrokerName.DEGIRO.display_name
+            'DEGIRO'
+        """
+        return self.long_name
+
+    @classmethod
+    def from_string(cls, value: str) -> "BrokerName":
+        """Convert a string to BrokerName enum.
+
+        Args:
+            value: Broker name as string
+
+        Returns:
+            BrokerName enum value
+
+        Raises:
+            ValueError: If broker name is not valid
+
+        Example:
+            >>> broker = BrokerName.from_string("degiro")
+            >>> assert broker == BrokerName.DEGIRO
+        """
+        try:
+            return cls(value.lower())
+        except ValueError as e:
+            raise ValueError(f"Invalid broker name: {value}. Valid options: {cls.all()}") from e
+
+    @classmethod
+    def all(cls) -> List[str]:
+        """Get list of all broker names.
+
+        Returns:
+            List of broker name strings
+
+        Example:
+            >>> BrokerName.all()
+            ['degiro', 'bitvavo', 'ibkr']
+        """
+        return [broker.value for broker in cls]
+
+    @classmethod
+    def normalize(cls, broker: Union["BrokerName", str]) -> str:
+        """Normalize broker input to string value.
+
+        Accepts both BrokerName enum and string, returns string value.
+        This is a convenience method for functions that accept both types.
+
+        Args:
+            broker: Broker name (can be string or BrokerName enum)
+
+        Returns:
+            Broker name as string
+
+        Example:
+            >>> BrokerName.normalize(BrokerName.DEGIRO)
+            'degiro'
+            >>> BrokerName.normalize("degiro")
+            'degiro'
+        """
+        return broker.value if isinstance(broker, cls) else broker
+
+    @classmethod
+    def is_valid(cls, broker: str) -> bool:
+        """Check if broker name is valid.
+
+        Args:
+            broker: Broker name to validate
+
+        Returns:
+            True if broker name is valid, False otherwise
+
+        Example:
+            >>> BrokerName.is_valid("degiro")
+            True
+            >>> BrokerName.is_valid("invalid_broker")
+            False
+        """
+        return broker in cls.all()
+
+    def __str__(self) -> str:
+        """Return string value of broker name."""
+        return self.value
+
+    def __repr__(self) -> str:
+        """Return unambiguous string representation for debugging.
+
+        Returns:
+            String in format "BrokerName.MEMBER_NAME"
+
+        Example:
+            >>> repr(BrokerName.IBKR)
+            'BrokerName.IBKR'
+        """
+        return f"{self.__class__.__name__}.{self.name}"

--- a/src/stonks_overwatch/core/factories/broker_factory.py
+++ b/src/stonks_overwatch/core/factories/broker_factory.py
@@ -9,6 +9,7 @@ eliminating the need for separate factory systems.
 from typing import Any, Dict, Optional
 
 from stonks_overwatch.config.base_config import BaseConfig
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.core.exceptions import ServiceFactoryException
 from stonks_overwatch.core.factories.broker_registry import (
     BrokerRegistry,
@@ -59,7 +60,7 @@ class BrokerFactory:
         self._cache_enabled = True
 
     # Configuration creation methods
-    def create_config(self, broker_name: str, **kwargs) -> Optional[BaseConfig]:
+    def create_config(self, broker_name: BrokerName, **kwargs) -> Optional[BaseConfig]:
         """
         Create broker configuration instance with caching.
 
@@ -102,12 +103,13 @@ class BrokerFactory:
             self.logger.error(f"Failed to create configuration for broker {broker_name}: {e}")
             raise BrokerFactoryError(f"Failed to create configuration for broker '{broker_name}': {e}") from e
 
-    def create_default_config(self, broker_name: str) -> Optional[BaseConfig]:
+    def create_default_config(self, broker_name: BrokerName) -> Optional[BaseConfig]:
         """
         Create default broker configuration instance.
 
         Args:
             broker_name: Name of the broker
+            **kwargs: Additional arguments to pass to the configuration constructor
 
         Returns:
             Default configuration instance if broker is registered, None otherwise
@@ -125,7 +127,7 @@ class BrokerFactory:
             self.logger.error(f"Failed to create default configuration for broker {broker_name}: {e}")
             raise BrokerFactoryError(f"Failed to create default configuration for broker '{broker_name}': {e}") from e
 
-    def create_config_from_dict(self, broker_name: str, data: dict) -> Optional[BaseConfig]:
+    def create_config_from_dict(self, broker_name: BrokerName, data: dict) -> Optional[BaseConfig]:
         """
         Create broker configuration instance from dictionary data.
 
@@ -150,7 +152,7 @@ class BrokerFactory:
             raise BrokerFactoryError(f"Failed to create configuration from dict for broker '{broker_name}': {e}") from e
 
     # Service creation methods with dependency injection
-    def create_service(self, broker_name: str, service_type: ServiceType, **kwargs) -> Optional[Any]:
+    def create_service(self, broker_name: BrokerName, service_type: ServiceType, **kwargs) -> Optional[Any]:
         """
         Create service instance with automatic configuration dependency injection.
 
@@ -162,6 +164,7 @@ class BrokerFactory:
         Returns:
             Service instance if available, None otherwise
         """
+
         # Check cache first
         if (
             self._cache_enabled
@@ -203,7 +206,7 @@ class BrokerFactory:
             ) from e
 
     # Typed service creation methods
-    def create_portfolio_service(self, broker_name: str, **kwargs) -> Optional[PortfolioServiceInterface]:
+    def create_portfolio_service(self, broker_name: BrokerName, **kwargs) -> Optional[PortfolioServiceInterface]:
         """
         Create a portfolio service instance for the specified broker.
 
@@ -219,7 +222,7 @@ class BrokerFactory:
 
         return self.create_service(broker_name, ServiceType.PORTFOLIO, **kwargs)
 
-    def create_transaction_service(self, broker_name: str, **kwargs) -> Optional[TransactionServiceInterface]:
+    def create_transaction_service(self, broker_name: BrokerName, **kwargs) -> Optional[TransactionServiceInterface]:
         """
         Create a transaction service instance for the specified broker.
 
@@ -230,12 +233,13 @@ class BrokerFactory:
         Returns:
             Transaction service instance if available, None otherwise
         """
+
         if not self._registry.broker_supports_service(broker_name, ServiceType.TRANSACTION):
             raise BrokerFactoryError(f"Broker '{broker_name}' does not support transaction service")
 
         return self.create_service(broker_name, ServiceType.TRANSACTION, **kwargs)
 
-    def create_deposit_service(self, broker_name: str, **kwargs) -> Optional[DepositServiceInterface]:
+    def create_deposit_service(self, broker_name: BrokerName, **kwargs) -> Optional[DepositServiceInterface]:
         """
         Create a deposit service instance for the specified broker.
 
@@ -251,7 +255,7 @@ class BrokerFactory:
 
         return self.create_service(broker_name, ServiceType.DEPOSIT, **kwargs)
 
-    def create_dividend_service(self, broker_name: str, **kwargs) -> Optional[DividendServiceInterface]:
+    def create_dividend_service(self, broker_name: BrokerName, **kwargs) -> Optional[DividendServiceInterface]:
         """
         Create a dividend service instance for the specified broker.
 
@@ -267,7 +271,7 @@ class BrokerFactory:
 
         return self.create_service(broker_name, ServiceType.DIVIDEND, **kwargs)
 
-    def create_fee_service(self, broker_name: str, **kwargs) -> Optional[Any]:
+    def create_fee_service(self, broker_name: BrokerName, **kwargs) -> Optional[Any]:
         """
         Create a fee service instance for the specified broker.
 
@@ -283,7 +287,7 @@ class BrokerFactory:
 
         return self.create_service(broker_name, ServiceType.FEE, **kwargs)
 
-    def create_account_service(self, broker_name: str, **kwargs) -> Optional[Any]:
+    def create_account_service(self, broker_name: BrokerName, **kwargs) -> Optional[Any]:
         """
         Create an account service instance for the specified broker.
 
@@ -299,7 +303,9 @@ class BrokerFactory:
 
         return self.create_service(broker_name, ServiceType.ACCOUNT, **kwargs)
 
-    def create_authentication_service(self, broker_name: str, **kwargs) -> Optional[AuthenticationServiceInterface]:
+    def create_authentication_service(
+        self, broker_name: BrokerName, **kwargs
+    ) -> Optional[AuthenticationServiceInterface]:
         """
         Create an authentication service instance for the specified broker.
 
@@ -316,7 +322,7 @@ class BrokerFactory:
         return self.create_service(broker_name, ServiceType.AUTHENTICATION, **kwargs)
 
     # Convenience methods
-    def create_all_services(self, broker_name: str, **kwargs) -> Dict[ServiceType, Any]:
+    def create_all_services(self, broker_name: BrokerName, **kwargs) -> Dict[ServiceType, Any]:
         """
         Create all supported services for a broker.
 
@@ -340,16 +346,16 @@ class BrokerFactory:
 
         return services
 
-    def get_available_brokers(self) -> list[str]:
+    def get_available_brokers(self) -> list[BrokerName]:
         """
         Get brokers available for both config and services.
 
         Returns:
-            List of broker names with both config and service registrations
+            List of BrokerName enums with both config and service registrations
         """
         return self._registry.get_fully_registered_brokers()
 
-    def is_broker_available(self, broker_name: str) -> bool:
+    def is_broker_available(self, broker_name: BrokerName) -> bool:
         """
         Check if a broker is fully available (both config and services registered).
 
@@ -359,9 +365,10 @@ class BrokerFactory:
         Returns:
             True if broker is fully available, False otherwise
         """
-        return broker_name in self._registry.get_fully_registered_brokers()
+        broker_str = BrokerName.normalize(broker_name)
+        return broker_str in self._registry.get_fully_registered_brokers()
 
-    def get_broker_capabilities(self, broker_name: str) -> list[ServiceType]:
+    def get_broker_capabilities(self, broker_name: BrokerName) -> list[ServiceType]:
         """
         Get the capabilities (service types) of a specific broker.
 
@@ -373,7 +380,7 @@ class BrokerFactory:
         """
         return self._registry.get_broker_capabilities(broker_name)
 
-    def broker_supports_service(self, broker_name: str, service_type: ServiceType) -> bool:
+    def broker_supports_service(self, broker_name: BrokerName, service_type: ServiceType) -> bool:
         """
         Check if a broker supports a specific service type.
 
@@ -387,7 +394,7 @@ class BrokerFactory:
         return self._registry.broker_supports_service(broker_name, service_type)
 
     # Cache management
-    def clear_cache(self, broker_name: Optional[str] = None) -> None:
+    def clear_cache(self, broker_name: Optional[BrokerName] = None) -> None:
         """
         Clear cached instances.
 
@@ -396,15 +403,16 @@ class BrokerFactory:
                         If None, clears all cached instances.
         """
         if broker_name:
-            self._config_instances.pop(broker_name, None)
-            self._service_instances.pop(broker_name, None)
-            self.logger.debug(f"Cleared cache for broker: {broker_name}")
+            broker_str = BrokerName.normalize(broker_name)
+            self._config_instances.pop(broker_str, None)
+            self._service_instances.pop(broker_str, None)
+            self.logger.debug(f"Cleared cache for broker: {broker_str}")
         else:
             self._config_instances.clear()
             self._service_instances.clear()
             self.logger.debug("Cleared all cached instances")
 
-    def update_broker_credentials(self, broker_name: str, **credentials) -> None:
+    def update_broker_credentials(self, broker_name: BrokerName, **credentials) -> None:
         """
         Update credentials for a specific broker.
 
@@ -424,12 +432,12 @@ class BrokerFactory:
             if config.credentials is None:
                 # Use a simple mapping for credential classes to avoid complexity
                 credential_classes = {
-                    "degiro": "stonks_overwatch.config.degiro.DegiroCredentials",
-                    "bitvavo": "stonks_overwatch.config.bitvavo.BitvavoCredentials",
-                    "ibkr": "stonks_overwatch.config.ibkr.IbkrCredentials",
+                    BrokerName.DEGIRO: "stonks_overwatch.config.degiro.DegiroCredentials",
+                    BrokerName.BITVAVO: "stonks_overwatch.config.bitvavo.BitvavoCredentials",
+                    BrokerName.IBKR: "stonks_overwatch.config.ibkr.IbkrCredentials",
                 }
 
-                credential_class_path = credential_classes.get(broker_name.lower())
+                credential_class_path = credential_classes.get(broker_name)
                 if not credential_class_path:
                     raise BrokerFactoryError(f"No credential class mapping for broker: {broker_name}")
 
@@ -486,7 +494,7 @@ class BrokerFactory:
         """
         try:
             self.update_broker_credentials(
-                "degiro",
+                BrokerName.DEGIRO,
                 username=username,
                 password=password,
                 int_account=int_account,

--- a/src/stonks_overwatch/core/interfaces/broker_service.py
+++ b/src/stonks_overwatch/core/interfaces/broker_service.py
@@ -7,6 +7,8 @@ All broker services should implement this interface to ensure consistency.
 
 from abc import ABC, abstractmethod
 
+from stonks_overwatch.constants import BrokerName
+
 
 class BrokerServiceInterface(ABC):
     """
@@ -44,12 +46,12 @@ class BrokerServiceInterface(ABC):
 
     @property
     @abstractmethod
-    def broker_name(self) -> str:
+    def broker_name(self) -> BrokerName:
         """
         Returns the name of the broker (e.g., 'DeGiro', 'Bitvavo').
 
         Returns:
-            str: The broker name
+            BrokerName: The broker name
         """
         pass
 

--- a/src/stonks_overwatch/core/interfaces/update_service.py
+++ b/src/stonks_overwatch/core/interfaces/update_service.py
@@ -6,6 +6,7 @@ from typing import Optional
 from django.db.utils import OperationalError
 
 from stonks_overwatch.config.base_config import BaseConfig
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.settings import STONKS_OVERWATCH_DATA_DIR
 from stonks_overwatch.utils.core.logger import StonksLogger
 
@@ -33,7 +34,7 @@ class AbstractUpdateService(ABC):
 
     def __init__(
         self,
-        broker_name: str,
+        broker_name: BrokerName,
         import_folder: Optional[str] = None,
         debug_mode: Optional[bool] = None,
         config: Optional[BaseConfig] = None,

--- a/src/stonks_overwatch/core/registry_setup.py
+++ b/src/stonks_overwatch/core/registry_setup.py
@@ -23,6 +23,7 @@ except Exception as e:
 from stonks_overwatch.config.bitvavo import BitvavoConfig
 from stonks_overwatch.config.degiro import DegiroConfig
 from stonks_overwatch.config.ibkr import IbkrConfig
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.core.factories.broker_registry import BrokerRegistry
 from stonks_overwatch.core.service_types import ServiceType
 from stonks_overwatch.services.brokers.bitvavo.services.account_service import (
@@ -92,8 +93,8 @@ from stonks_overwatch.services.brokers.ibkr.services.transactions import (
 )
 
 # Configuration-driven broker definitions
-BROKER_CONFIGS: Dict[str, Dict[str, Any]] = {
-    "degiro": {
+BROKER_CONFIGS: Dict[BrokerName, Dict[str, Any]] = {
+    BrokerName.DEGIRO: {
         "config": DegiroConfig,
         "services": {
             ServiceType.PORTFOLIO: DeGiroPortfolioService,
@@ -106,7 +107,7 @@ BROKER_CONFIGS: Dict[str, Dict[str, Any]] = {
         },
         "supports_complete_registration": True,
     },
-    "bitvavo": {
+    BrokerName.BITVAVO: {
         "config": BitvavoConfig,
         "services": {
             ServiceType.PORTFOLIO: BitvavoPortfolioService,
@@ -119,7 +120,7 @@ BROKER_CONFIGS: Dict[str, Dict[str, Any]] = {
         },
         "supports_complete_registration": True,
     },
-    "ibkr": {
+    BrokerName.IBKR: {
         "config": IbkrConfig,
         "services": {
             ServiceType.PORTFOLIO: IbkrPortfolioService,
@@ -135,7 +136,7 @@ BROKER_CONFIGS: Dict[str, Dict[str, Any]] = {
 }
 
 
-def get_broker_config(broker_name: str) -> Optional[Dict[str, Any]]:
+def get_broker_config(broker_name: BrokerName) -> Optional[Dict[str, Any]]:
     """
     Get the configuration for a specific broker.
 
@@ -148,7 +149,7 @@ def get_broker_config(broker_name: str) -> Optional[Dict[str, Any]]:
     return BROKER_CONFIGS.get(broker_name)
 
 
-def get_all_broker_names() -> list[str]:
+def get_all_broker_names() -> list[BrokerName]:
     """
     Get all available broker names from the configuration.
 

--- a/src/stonks_overwatch/jobs/jobs_scheduler.py
+++ b/src/stonks_overwatch/jobs/jobs_scheduler.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
+from stonks_overwatch.constants.brokers import BrokerName
 from stonks_overwatch.core.exceptions import CredentialsException
 from stonks_overwatch.services.brokers.bitvavo.services.update_service import UpdateService as BitvavoUpdateService
 from stonks_overwatch.services.brokers.degiro.services.update_service import UpdateService as DegiroUpdateService
@@ -21,7 +22,7 @@ class JobsScheduler:
 
     # Broker configuration mapping
     BROKER_CONFIGS = {
-        "degiro": {
+        BrokerName.DEGIRO.value: {
             "job_id": "update_degiro_portfolio",
             "check_offline": True,
             "update_service_class": DegiroUpdateService,
@@ -29,7 +30,7 @@ class JobsScheduler:
             "connection_check": "is_connected",
             "connection_method": "connect",
         },
-        "bitvavo": {
+        BrokerName.BITVAVO.value: {
             "job_id": "update_bitvavo_portfolio",
             "check_offline": True,
             "update_service_class": BitvavoUpdateService,
@@ -37,7 +38,7 @@ class JobsScheduler:
             "connection_check": "get_client",
             "connection_method": None,  # Handled during initialization
         },
-        "ibkr": {
+        BrokerName.IBKR.value: {
             "job_id": "update_ibkr_portfolio",
             "check_offline": False,
             "update_service_class": IbkrUpdateService,
@@ -61,7 +62,7 @@ class JobsScheduler:
         ]
 
     @classmethod
-    def _create_update_method(cls, broker_name):
+    def _create_update_method(cls, broker_name: BrokerName):
         """Create a generic update method for a specific broker"""
 
         def update_method():
@@ -70,7 +71,7 @@ class JobsScheduler:
         return update_method
 
     @classmethod
-    def _update_broker_portfolio(cls, broker_name):
+    def _update_broker_portfolio(cls, broker_name: BrokerName):
         """Generic method to update any broker portfolio"""
         broker_config = cls.BROKER_CONFIGS.get(broker_name)
         if not broker_config:

--- a/src/stonks_overwatch/middleware/authentication.py
+++ b/src/stonks_overwatch/middleware/authentication.py
@@ -10,6 +10,7 @@ from typing import Optional
 from django.shortcuts import redirect
 from django.urls import resolve
 
+from stonks_overwatch.constants.brokers import BrokerName
 from stonks_overwatch.core.authentication_locator import get_authentication_service
 from stonks_overwatch.core.factories.broker_factory import BrokerFactory
 from stonks_overwatch.core.factories.broker_registry import BrokerRegistry
@@ -107,7 +108,7 @@ class AuthenticationMiddleware:
 
             for broker_name in registered_brokers:
                 # Skip DEGIRO as it's already checked above
-                if broker_name == "degiro":
+                if broker_name == BrokerName.DEGIRO:
                     continue
 
                 # Check broker-specific session key

--- a/src/stonks_overwatch/migrations/0007_reset_brokers_configuration.py
+++ b/src/stonks_overwatch/migrations/0007_reset_brokers_configuration.py
@@ -2,9 +2,11 @@ import datetime
 
 from django.db import migrations
 
+from stonks_overwatch.constants import BrokerName
+
 # With the introduction to allow login with different brokers, DEGIRO is not a default anymore
 # This forces to reset all the brokers configuration
-BROKERS = ["degiro", "bitvavo", "ibkr"]
+BROKERS = BrokerName.all()
 
 
 def load_broker_config(apps, schema_editor):
@@ -13,7 +15,7 @@ def load_broker_config(apps, schema_editor):
         enabled = False
         credentials = {}
         start_date = datetime.date(2020, 1, 1)
-        update_frequency = 15 if broker == "ibkr" else 5
+        update_frequency = 15 if broker == BrokerName.IBKR else 5
 
         broker_configuration.objects.update_or_create(
             broker_name=broker,

--- a/src/stonks_overwatch/services/brokers/bitvavo/client/bitvavo_client.py
+++ b/src/stonks_overwatch/services/brokers/bitvavo/client/bitvavo_client.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 from python_bitvavo_api.bitvavo import Bitvavo, createPostfix
 
 from stonks_overwatch.config.bitvavo import BitvavoConfig
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.utils.core.logger import StonksLogger
 from stonks_overwatch.utils.core.singleton import singleton
 
@@ -46,7 +47,7 @@ class BitvavoService:
                 from stonks_overwatch.config.base_config import resolve_config_from_factory
 
                 # Get and resolve Bitvavo configuration
-                self.bitvavo_config = resolve_config_from_factory("bitvavo", BitvavoConfig)
+                self.bitvavo_config = resolve_config_from_factory(BrokerName.BITVAVO, BitvavoConfig)
             except ImportError as e:
                 raise ImportError(f"Failed to import BrokerFactory: {e}") from e
 

--- a/src/stonks_overwatch/services/brokers/bitvavo/services/update_service.py
+++ b/src/stonks_overwatch/services/brokers/bitvavo/services/update_service.py
@@ -5,6 +5,7 @@ from typing import Optional
 from degiro_connector.quotecast.models.chart import Interval
 
 from stonks_overwatch.config.bitvavo import BitvavoConfig
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.core.interfaces.base_service import BaseService
 from stonks_overwatch.core.interfaces.update_service import AbstractUpdateService
 from stonks_overwatch.services.brokers.bitvavo.client.bitvavo_client import BitvavoService
@@ -35,7 +36,7 @@ class UpdateService(BaseService, AbstractUpdateService):
             Optional configuration instance for dependency injection.
         """
         # Initialize AbstractUpdateService first (has no super() calls to interfere)
-        AbstractUpdateService.__init__(self, "Bitvavo", import_folder, debug_mode, config)
+        AbstractUpdateService.__init__(self, BrokerName.BITVAVO, import_folder, debug_mode, config)
         # Then manually set BaseService attributes without calling its __init__
         self._injected_config = config
         self._global_config = None

--- a/src/stonks_overwatch/services/brokers/degiro/client/degiro_client.py
+++ b/src/stonks_overwatch/services/brokers/degiro/client/degiro_client.py
@@ -14,6 +14,7 @@ from degiro_connector.trading.models.credentials import Credentials
 import stonks_overwatch.settings
 from stonks_overwatch.config.base_config import BaseConfig
 from stonks_overwatch.config.degiro import DegiroConfig, DegiroCredentials
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.settings import TIME_ZONE
 from stonks_overwatch.utils.core.localization import LocalizationUtility
 from stonks_overwatch.utils.core.logger import StonksLogger
@@ -46,7 +47,7 @@ class CredentialsManager:
                 from stonks_overwatch.config.base_config import resolve_config_from_factory
 
                 # Get and resolve DeGiro configuration
-                degiro_config = resolve_config_from_factory("degiro", DegiroConfig)
+                degiro_config = resolve_config_from_factory(BrokerName.DEGIRO, DegiroConfig)
             except ImportError as e:
                 raise ImportError(f"Failed to import BrokerFactory: {e}") from e
 
@@ -148,7 +149,7 @@ class DeGiroService:
                 from stonks_overwatch.config.base_config import resolve_config_from_factory
 
                 # Get and resolve DeGiro configuration
-                self.degiro_config = resolve_config_from_factory("degiro", DegiroConfig)
+                self.degiro_config = resolve_config_from_factory(BrokerName.DEGIRO, DegiroConfig)
             except ImportError:
                 # If BrokerFactory is not available, AuthenticationService should provide config
                 pass

--- a/src/stonks_overwatch/services/brokers/degiro/services/authentication_service.py
+++ b/src/stonks_overwatch/services/brokers/degiro/services/authentication_service.py
@@ -13,6 +13,7 @@ from degiro_connector.core.exceptions import DeGiroConnectionError, MaintenanceE
 from django.http import HttpRequest
 
 from stonks_overwatch.config.degiro import DegiroCredentials
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.core.interfaces.authentication_service import (
     AuthenticationResponse,
     AuthenticationResult,
@@ -52,8 +53,6 @@ class DegiroAuthenticationService(AuthenticationServiceInterface, BaseService):
     - Maintenance mode scenarios
     """
 
-    BROKER_NAME = "degiro"
-
     def __init__(
         self,
         session_manager: Optional[SessionManagerInterface] = None,
@@ -81,9 +80,9 @@ class DegiroAuthenticationService(AuthenticationServiceInterface, BaseService):
         self.degiro_service = degiro_service or DeGiroService()
 
     @property
-    def broker_name(self) -> str:
+    def broker_name(self) -> BrokerName:
         """Return the broker name."""
-        return self.BROKER_NAME
+        return BrokerName.DEGIRO
 
     def is_user_authenticated(self, request: HttpRequest) -> bool:
         """
@@ -519,7 +518,7 @@ class DegiroAuthenticationService(AuthenticationServiceInterface, BaseService):
             from stonks_overwatch.core.factories.broker_factory import BrokerFactory
 
             broker_factory = BrokerFactory()
-            degiro_config = broker_factory.create_config("degiro")
+            degiro_config = broker_factory.create_config(BrokerName.DEGIRO)
 
             return degiro_config is not None and degiro_config.is_enabled()
 
@@ -538,7 +537,7 @@ class DegiroAuthenticationService(AuthenticationServiceInterface, BaseService):
             from stonks_overwatch.core.factories.broker_factory import BrokerFactory
 
             broker_factory = BrokerFactory()
-            degiro_config = broker_factory.create_config("degiro")
+            degiro_config = broker_factory.create_config(BrokerName.DEGIRO)
 
             return degiro_config is not None and degiro_config.offline_mode
 
@@ -846,7 +845,7 @@ class DegiroAuthenticationService(AuthenticationServiceInterface, BaseService):
         This ensures the broker is marked as enabled regardless of remember_me setting.
         """
         try:
-            degiro_configuration = BrokersConfigurationRepository.get_broker_by_name("degiro")
+            degiro_configuration = BrokersConfigurationRepository.get_broker_by_name(BrokerName.DEGIRO)
             if degiro_configuration:
                 degiro_configuration.enabled = True
                 BrokersConfigurationRepository.save_broker_configuration(degiro_configuration)

--- a/src/stonks_overwatch/services/brokers/degiro/services/update_service.py
+++ b/src/stonks_overwatch/services/brokers/degiro/services/update_service.py
@@ -10,6 +10,7 @@ from django.core.cache import cache
 from django.utils import timezone as django_timezone
 
 from stonks_overwatch.config.degiro import DegiroConfig
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.core.interfaces.base_service import BaseService
 from stonks_overwatch.core.interfaces.update_service import AbstractUpdateService
 from stonks_overwatch.services.brokers.degiro.client.constants import CurrencyFX
@@ -67,7 +68,7 @@ class UpdateService(BaseService, AbstractUpdateService):
             If True, the service will attempt to connect to DeGiro upon initialization.
         """
         # Initialize AbstractUpdateService first (has no super() calls to interfere)
-        AbstractUpdateService.__init__(self, "DEGIRO", import_folder, debug_mode, config)
+        AbstractUpdateService.__init__(self, BrokerName.DEGIRO, import_folder, debug_mode, config)
         # Then manually set BaseService attributes without calling its __init__
         self._global_config = None
         self._injected_config = config
@@ -75,7 +76,7 @@ class UpdateService(BaseService, AbstractUpdateService):
             from stonks_overwatch.core.factories.broker_factory import BrokerFactory
 
             broker_factory = BrokerFactory()
-            self._injected_config = broker_factory.create_config("degiro")
+            self._injected_config = broker_factory.create_config(BrokerName.DEGIRO)
 
         # Pass injected config to DeGiro service for proper credential access
         self.degiro_service = DeGiroService(config=self._injected_config)

--- a/src/stonks_overwatch/services/brokers/ibkr/client/ibkr_service.py
+++ b/src/stonks_overwatch/services/brokers/ibkr/client/ibkr_service.py
@@ -10,6 +10,7 @@ from ibind import IbkrClient
 from ibind.oauth.oauth1a import OAuth1aConfig
 
 from stonks_overwatch.config.ibkr import IbkrConfig
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.utils.core.logger import StonksLogger
 from stonks_overwatch.utils.core.singleton import singleton
 
@@ -48,7 +49,7 @@ class IbkrService:
                 from stonks_overwatch.config.base_config import resolve_config_from_factory
 
                 # Get and resolve IBKR configuration
-                ibkr_config = resolve_config_from_factory("ibkr", IbkrConfig)
+                ibkr_config = resolve_config_from_factory(BrokerName.IBKR, IbkrConfig)
             except ImportError as e:
                 raise ImportError(f"Failed to import BrokerFactory: {e}") from e
 

--- a/src/stonks_overwatch/services/brokers/ibkr/services/deposit_service.py
+++ b/src/stonks_overwatch/services/brokers/ibkr/services/deposit_service.py
@@ -9,6 +9,7 @@ through their API in the same way as other brokers.
 from typing import Dict, List, Optional
 
 from stonks_overwatch.config.base_config import BaseConfig
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.core.interfaces.base_service import BaseService
 from stonks_overwatch.core.interfaces.deposit_service import DepositServiceInterface
 from stonks_overwatch.services.brokers.ibkr.client.ibkr_service import IbkrService
@@ -38,9 +39,9 @@ class DepositsService(BaseService, DepositServiceInterface):
         self.ibkr_service = IbkrService()
 
     @property
-    def broker_name(self) -> str:
+    def broker_name(self) -> BrokerName:
         """Return the broker name."""
-        return "ibkr"
+        return BrokerName.IBKR
 
     def get_cash_deposits(self) -> List[Deposit]:
         """

--- a/src/stonks_overwatch/services/brokers/ibkr/services/fee_service.py
+++ b/src/stonks_overwatch/services/brokers/ibkr/services/fee_service.py
@@ -9,6 +9,7 @@ through their API in the same way as other brokers.
 from typing import List, Optional
 
 from stonks_overwatch.config.base_config import BaseConfig
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.core.interfaces.base_service import BaseService
 from stonks_overwatch.core.interfaces.fee_service import FeeServiceInterface
 from stonks_overwatch.services.brokers.ibkr.client.ibkr_service import IbkrService
@@ -38,9 +39,9 @@ class FeeService(BaseService, FeeServiceInterface):
         self.ibkr_service = IbkrService()
 
     @property
-    def broker_name(self) -> str:
+    def broker_name(self) -> BrokerName:
         """Return the broker name."""
-        return "ibkr"
+        return BrokerName.IBKR
 
     def get_fees(self) -> List[Fee]:
         """

--- a/src/stonks_overwatch/services/brokers/ibkr/services/update_service.py
+++ b/src/stonks_overwatch/services/brokers/ibkr/services/update_service.py
@@ -4,6 +4,7 @@ from typing import Optional
 from django.core.cache import cache
 
 from stonks_overwatch.config.ibkr import IbkrConfig
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.core.interfaces.base_service import DependencyInjectionMixin
 from stonks_overwatch.core.interfaces.update_service import AbstractUpdateService
 from stonks_overwatch.services.brokers.ibkr.client.ibkr_service import IbkrService
@@ -29,7 +30,7 @@ class UpdateService(DependencyInjectionMixin, AbstractUpdateService):
         """
         # Initialize AbstractUpdateService first
         AbstractUpdateService.__init__(
-            self, broker_name="ibkr", import_folder=import_folder, debug_mode=debug_mode, config=config
+            self, broker_name=BrokerName.IBKR, import_folder=import_folder, debug_mode=debug_mode, config=config
         )
         # Set up dependency injection attributes manually to avoid super() chain conflicts
         self._injected_config = config

--- a/src/stonks_overwatch/services/brokers/models.py
+++ b/src/stonks_overwatch/services/brokers/models.py
@@ -4,6 +4,7 @@ from django.db import models
 from stonks_overwatch.utils.core.logger import StonksLogger
 
 from .encryption_utils import decrypt_dict, encrypt_dict
+from ...constants import BrokerName
 
 
 class BrokersConfiguration(models.Model):
@@ -55,11 +56,11 @@ class BrokersConfigurationRepository:
 
     @staticmethod
     @sync_to_async
-    def get_broker_by_name_async(broker_name) -> BrokersConfiguration | None:
+    def get_broker_by_name_async(broker_name: BrokerName) -> BrokersConfiguration | None:
         return BrokersConfigurationRepository.get_broker_by_name(broker_name)
 
     @staticmethod
-    def get_broker_by_name(broker_name) -> BrokersConfiguration | None:
+    def get_broker_by_name(broker_name: BrokerName) -> BrokersConfiguration | None:
         try:
             return BrokersConfiguration.objects.get(broker_name=broker_name)
         except BrokersConfiguration.DoesNotExist:

--- a/src/stonks_overwatch/services/utilities/authentication_credential_service.py
+++ b/src/stonks_overwatch/services/utilities/authentication_credential_service.py
@@ -11,6 +11,7 @@ from typing import Optional, Tuple
 from django.http import HttpRequest
 
 from stonks_overwatch.config.degiro import DegiroCredentials
+from stonks_overwatch.constants.brokers import BrokerName
 from stonks_overwatch.core.interfaces.base_service import BaseService
 from stonks_overwatch.core.interfaces.credential_service import CredentialServiceInterface
 
@@ -128,7 +129,7 @@ class AuthenticationCredentialService(CredentialServiceInterface, BaseService):
             Optional[DegiroCredentials]: Credentials if found in database, None otherwise
         """
         try:
-            degiro_configuration = self._get_brokers_repository().get_broker_by_name("degiro")
+            degiro_configuration = self._get_brokers_repository().get_broker_by_name(BrokerName.DEGIRO)
             if degiro_configuration and degiro_configuration.credentials:
                 credentials_data = degiro_configuration.credentials
                 username = credentials_data.get("username")
@@ -164,7 +165,7 @@ class AuthenticationCredentialService(CredentialServiceInterface, BaseService):
             from stonks_overwatch.core.factories.broker_factory import BrokerFactory
 
             broker_factory = BrokerFactory()
-            degiro_config = broker_factory.create_config("degiro")
+            degiro_config = broker_factory.create_config(BrokerName.DEGIRO)
 
             if degiro_config and degiro_config.credentials:
                 config_credentials = degiro_config.get_credentials
@@ -240,7 +241,7 @@ class AuthenticationCredentialService(CredentialServiceInterface, BaseService):
             bool: True if credentials were stored successfully, False otherwise
         """
         try:
-            degiro_configuration = self._get_brokers_repository().get_broker_by_name("degiro")
+            degiro_configuration = self._get_brokers_repository().get_broker_by_name(BrokerName.DEGIRO)
             if degiro_configuration.credentials is None:
                 degiro_configuration.credentials = {}
 
@@ -425,7 +426,7 @@ class AuthenticationCredentialService(CredentialServiceInterface, BaseService):
             bool: True if credentials were cleared successfully, False otherwise
         """
         try:
-            degiro_configuration = self._get_brokers_repository().get_broker_by_name("degiro")
+            degiro_configuration = self._get_brokers_repository().get_broker_by_name(BrokerName.DEGIRO)
             if degiro_configuration.credentials:
                 # Clear the credentials but keep the configuration object
                 degiro_configuration.credentials = {}

--- a/src/stonks_overwatch/services/utilities/authentication_session_manager.py
+++ b/src/stonks_overwatch/services/utilities/authentication_session_manager.py
@@ -11,6 +11,7 @@ from typing import Dict, Optional
 from django.http import HttpRequest
 
 from stonks_overwatch.config.degiro import DegiroCredentials
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.core.interfaces.base_service import BaseService
 from stonks_overwatch.core.interfaces.session_manager import SessionManagerInterface
 from stonks_overwatch.utils.core.logger import StonksLogger
@@ -30,11 +31,11 @@ class AuthenticationSessionManager(SessionManagerInterface, BaseService):
     """
 
     # Session keys for authentication data
-    SESSION_IS_AUTHENTICATED = SessionKeys.get_authenticated_key("degiro")
+    SESSION_IS_AUTHENTICATED = SessionKeys.get_authenticated_key(BrokerName.DEGIRO)
     SESSION_ID_KEY = "session_id"
-    SESSION_CREDENTIALS_KEY = SessionKeys.get_credentials_key("degiro")
-    SESSION_SHOW_OTP_KEY = SessionKeys.get_totp_required_key("degiro")
-    SESSION_IN_APP_AUTH_KEY = SessionKeys.get_in_app_auth_required_key("degiro")
+    SESSION_CREDENTIALS_KEY = SessionKeys.get_credentials_key(BrokerName.DEGIRO)
+    SESSION_SHOW_OTP_KEY = SessionKeys.get_totp_required_key(BrokerName.DEGIRO)
+    SESSION_IN_APP_AUTH_KEY = SessionKeys.get_in_app_auth_required_key(BrokerName.DEGIRO)
 
     logger = StonksLogger.get_logger("stonks_overwatch.auth_session_manager", "[AUTH|SESSION_MANAGER]")
 

--- a/src/stonks_overwatch/services/utilities/credential_validator.py
+++ b/src/stonks_overwatch/services/utilities/credential_validator.py
@@ -1,5 +1,6 @@
 from typing import Any, Callable, Dict
 
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.utils.core.logger import StonksLogger
 
 
@@ -12,7 +13,7 @@ class CredentialValidator:
     logger = StonksLogger.get_logger("stonks_overwatch.utils.credential_validator", "[CRED_VALIDATOR]")
 
     @classmethod
-    def has_valid_credentials(cls, broker_name: str, credentials: Any) -> bool:
+    def has_valid_credentials(cls, broker_name: BrokerName, credentials: Any) -> bool:
         """
         Validate that broker credentials are not placeholders and meet minimum requirements.
 
@@ -28,9 +29,9 @@ class CredentialValidator:
 
         try:
             validators: Dict[str, Callable[[Any], bool]] = {
-                "degiro": cls._validate_degiro,
-                "bitvavo": cls._validate_bitvavo,
-                "ibkr": cls._validate_ibkr,
+                BrokerName.DEGIRO: cls._validate_degiro,
+                BrokerName.BITVAVO: cls._validate_bitvavo,
+                BrokerName.IBKR: cls._validate_ibkr,
             }
 
             validator = validators.get(broker_name)

--- a/src/stonks_overwatch/templates/login.html
+++ b/src/stonks_overwatch/templates/login.html
@@ -89,7 +89,7 @@
                              class="broker-logo mb-3">
                         <h5 class="card-title mb-2">{{ broker.display_name }}</h5>
                         <p class="card-text text-muted small mb-3">{{ broker.description }}</p>
-                        {% if not broker.enabled %}
+                        {% if not broker.stable %}
                             <span class="badge bg-warning text-dark">Experimental</span>
                         {% endif %}
                     </div>

--- a/src/stonks_overwatch/templatetags/custom_tags.py
+++ b/src/stonks_overwatch/templatetags/custom_tags.py
@@ -2,6 +2,7 @@ from django import template
 from django.template import RequestContext
 from django.utils import timezone
 
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.services.aggregators.portfolio_aggregator import PortfolioAggregatorService
 from stonks_overwatch.services.brokers.degiro.client.degiro_client import DeGiroOfflineModeError, DeGiroService
 from stonks_overwatch.services.brokers.degiro.services.update_service import UpdateService
@@ -34,7 +35,7 @@ def is_connected_to_degiro() -> bool:
         from stonks_overwatch.core.factories.broker_factory import BrokerFactory
 
         broker_factory = BrokerFactory()
-        degiro_config = broker_factory.create_config("degiro")
+        degiro_config = broker_factory.create_config(BrokerName.DEGIRO)
 
         if degiro_config and degiro_config.is_enabled():
             degiro_client = DeGiroService()

--- a/src/stonks_overwatch/utils/core/session_keys.py
+++ b/src/stonks_overwatch/utils/core/session_keys.py
@@ -1,7 +1,13 @@
+from stonks_overwatch.constants.brokers import BrokerName
+
+
 class SessionKeys:
     """
     Central repository for session keys used across the application.
     Prevents hardcoded strings and typos.
+
+    Methods accept both BrokerName enum and string values for flexibility.
+    Using BrokerName enum is recommended for type safety.
     """
 
     # Generic templates
@@ -10,27 +16,54 @@ class SessionKeys:
     _BROKER_IN_APP_AUTH_REQUIRED = "{}_in_app_auth_required"
     _BROKER_CREDENTIALS = "{}_credentials"
 
-    # Legacy/Specific keys
-    DEGIRO_CREDENTIALS = "degiro_credentials"
-
     @classmethod
-    def get_authenticated_key(cls, broker_name: str) -> str:
-        """Get the session key for checking if a broker is authenticated."""
+    def get_authenticated_key(cls, broker_name: BrokerName) -> str:
+        """Get the session key for checking if a broker is authenticated.
+
+        Args:
+            broker_name: Broker name
+
+        Returns:
+            Session key string
+
+        Example:
+            >>> SessionKeys.get_authenticated_key(BrokerName.DEGIRO)
+            'degiro_authenticated'
+        """
         return cls._BROKER_AUTHENTICATED.format(broker_name)
 
     @classmethod
-    def get_totp_required_key(cls, broker_name: str) -> str:
-        """Get the session key for checking if TOTP is required for a broker."""
+    def get_totp_required_key(cls, broker_name: BrokerName) -> str:
+        """Get the session key for checking if TOTP is required for a broker.
+
+        Args:
+            broker_name: Broker name
+
+        Returns:
+            Session key string
+        """
         return cls._BROKER_TOTP_REQUIRED.format(broker_name)
 
     @classmethod
-    def get_in_app_auth_required_key(cls, broker_name: str) -> str:
-        """Get the session key for checking if in-app authentication is required."""
+    def get_in_app_auth_required_key(cls, broker_name: BrokerName) -> str:
+        """Get the session key for checking if in-app authentication is required.
+
+        Args:
+            broker_name: Broker name
+
+        Returns:
+            Session key string
+        """
         return cls._BROKER_IN_APP_AUTH_REQUIRED.format(broker_name)
 
     @classmethod
-    def get_credentials_key(cls, broker_name: str) -> str:
-        """Get the session key for storing broker credentials (enc/references)."""
-        if broker_name == "degiro":
-            return cls.DEGIRO_CREDENTIALS
+    def get_credentials_key(cls, broker_name: BrokerName) -> str:
+        """Get the session key for storing broker credentials (enc/references).
+
+        Args:
+            broker_name: Broker name
+
+        Returns:
+            Session key string
+        """
         return cls._BROKER_CREDENTIALS.format(broker_name)

--- a/src/stonks_overwatch/views/root_redirect.py
+++ b/src/stonks_overwatch/views/root_redirect.py
@@ -2,6 +2,7 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect
 from django.views import View
 
+from stonks_overwatch.constants.brokers import BrokerName
 from stonks_overwatch.core.factories.broker_factory import BrokerFactory
 from stonks_overwatch.core.factories.broker_registry import BrokerRegistry
 from stonks_overwatch.utils.core.logger import StonksLogger
@@ -94,13 +95,8 @@ class RootRedirectView(View):
         """
         try:
             # Check session for authentication status for any broker
-            broker_sessions = [
-                SessionKeys.get_authenticated_key("degiro"),
-                SessionKeys.get_authenticated_key("bitvavo"),
-                SessionKeys.get_authenticated_key("ibkr"),
-            ]
-
-            for session_key in broker_sessions:
+            for broker_name in BrokerName.all():
+                session_key = SessionKeys.get_authenticated_key(broker_name)
                 if request.session.get(session_key, False):
                     return True
 

--- a/src/stonks_overwatch/views/settings.py
+++ b/src/stonks_overwatch/views/settings.py
@@ -5,6 +5,7 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views import View
 
+from stonks_overwatch.constants.brokers import BrokerName
 from stonks_overwatch.services.brokers.models import BrokersConfigurationRepository
 from stonks_overwatch.utils.core.logger import StonksLogger
 from stonks_overwatch.utils.core.theme import get_theme_colors
@@ -40,9 +41,9 @@ class SettingsView(View):
         is_ajax_request = request.headers.get("X-Requested-With") == "XMLHttpRequest"
 
         # Load broker configurations
-        degiro_config = self.repository.get_broker_by_name("degiro")
-        bitvavo_config = self.repository.get_broker_by_name("bitvavo")
-        ibkr_config = self.repository.get_broker_by_name("ibkr")
+        degiro_config = self.repository.get_broker_by_name(BrokerName.DEGIRO.value)
+        bitvavo_config = self.repository.get_broker_by_name(BrokerName.BITVAVO.value)
+        ibkr_config = self.repository.get_broker_by_name(BrokerName.IBKR.value)
 
         # Handle dark mode (for native app WebView)
         dark_mode_param = request.GET.get("dark_mode", "0")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,10 +105,11 @@ def _register_config_classes(registry):
     from stonks_overwatch.config.bitvavo import BitvavoConfig
     from stonks_overwatch.config.degiro import DegiroConfig
     from stonks_overwatch.config.ibkr import IbkrConfig
+    from stonks_overwatch.constants import BrokerName
 
-    registry.register_broker_config("degiro", DegiroConfig)
-    registry.register_broker_config("bitvavo", BitvavoConfig)
-    registry.register_broker_config("ibkr", IbkrConfig)
+    registry.register_broker_config(BrokerName.DEGIRO, DegiroConfig)
+    registry.register_broker_config(BrokerName.BITVAVO, BitvavoConfig)
+    registry.register_broker_config(BrokerName.IBKR, IbkrConfig)
 
 
 def _import_real_services():

--- a/tests/stonks_overwatch/config/test_config.py
+++ b/tests/stonks_overwatch/config/test_config.py
@@ -2,6 +2,7 @@ import pathlib
 
 from stonks_overwatch.config.base_config import BaseConfig
 from stonks_overwatch.config.config import Config
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.core.factories.broker_factory import BrokerFactory
 from stonks_overwatch.services.models import PortfolioId
 
@@ -27,7 +28,7 @@ def test_config_init():
     assert config.base_currency == base_currency
 
     # Test that broker configs can be retrieved via the unified factory
-    degiro_config = config.get_broker_config("degiro")
+    degiro_config = config.get_broker_config(BrokerName.DEGIRO)
     assert degiro_config is not None
     assert isinstance(degiro_config, BaseConfig)
 
@@ -51,7 +52,7 @@ def test_config_from_dict():
 
     assert config.base_currency == base_currency
     # Broker configs are loaded on-demand via BrokerFactory
-    degiro_config = config.get_broker_config("degiro")
+    degiro_config = config.get_broker_config(BrokerName.DEGIRO)
     assert degiro_config is not None
 
 
@@ -60,7 +61,7 @@ def test_config_from_dict_empty():
     config = Config.from_dict({})
     assert config.base_currency == Config.DEFAULT_BASE_CURRENCY
     # Broker configs are available via unified factory
-    assert config.get_broker_config("degiro") is not None
+    assert config.get_broker_config(BrokerName.DEGIRO) is not None
 
 
 def test_config_from_json_file():
@@ -70,7 +71,7 @@ def test_config_from_json_file():
 
     assert config.base_currency == "EUR"  # From sample config file
     # Verify broker configs can be loaded
-    assert config.get_broker_config("degiro") is not None
+    assert config.get_broker_config(BrokerName.DEGIRO) is not None
 
 
 def test_config_from_json_file_invalid():
@@ -85,8 +86,8 @@ def test_config_default():
 
     assert config.base_currency == "EUR"
     # Verify broker configs are available via unified factory
-    assert config.get_broker_config("degiro") is not None
-    assert config.get_broker_config("bitvavo") is not None
+    assert config.get_broker_config(BrokerName.DEGIRO) is not None
+    assert config.get_broker_config(BrokerName.DEGIRO) is not None
 
 
 def test_config_default_without_config_file():
@@ -95,7 +96,7 @@ def test_config_default_without_config_file():
 
     assert config.base_currency == "EUR"
     # Even without config file, broker configs should be available via defaults
-    assert config.get_broker_config("degiro") is not None
+    assert config.get_broker_config(BrokerName.DEGIRO) is not None
 
 
 def test_config_portfolio_status():
@@ -117,7 +118,7 @@ def test_config_degiro_status():
     assert isinstance(degiro_enabled, bool)
 
     # Test getting DeGiro config directly
-    degiro_config = config.get_broker_config("degiro")
+    degiro_config = config.get_broker_config(BrokerName.DEGIRO)
     assert degiro_config is not None
 
 
@@ -130,7 +131,7 @@ def test_config_bitvavo_status():
     assert isinstance(bitvavo_enabled, bool)
 
     # Test getting Bitvavo config directly
-    bitvavo_config = config.get_broker_config("bitvavo")
+    bitvavo_config = config.get_broker_config(BrokerName.BITVAVO)
     assert bitvavo_config is not None
 
 

--- a/tests/stonks_overwatch/core/factories/test_broker_registry.py
+++ b/tests/stonks_overwatch/core/factories/test_broker_registry.py
@@ -166,16 +166,6 @@ class TestBrokerRegistry:
         assert self.registry.is_config_registered("testbroker")
         assert self.registry.get_config_class("testbroker") == MockBrokerConfig
 
-    def test_register_broker_config_invalid_name(self):
-        """Test broker configuration registration with invalid name."""
-        with pytest.raises(BrokerRegistryValidationError, match="Broker name must be a non-empty string"):
-            self.registry.register_broker_config("", MockBrokerConfig)
-
-        with pytest.raises(
-            BrokerRegistryValidationError, match="Broker name must contain only alphanumeric characters"
-        ):
-            self.registry.register_broker_config("test-broker", MockBrokerConfig)
-
     def test_register_broker_config_invalid_class(self):
         """Test broker configuration registration with invalid config class."""
         with pytest.raises(BrokerRegistryValidationError, match="config_class must be a class type"):

--- a/tests/stonks_overwatch/middleware/test_authentication.py
+++ b/tests/stonks_overwatch/middleware/test_authentication.py
@@ -7,6 +7,7 @@ authentication logic for all brokers.
 
 from django.http import HttpRequest, HttpResponse
 
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.middleware.authentication import AuthenticationMiddleware
 
 from django.test import TestCase
@@ -78,8 +79,8 @@ class TestAuthenticationMiddleware(TestCase):
         """Test middleware checks authentication when brokers are configured."""
         mock_resolve.return_value.url_name = "dashboard"
 
-        # Mock configured broker
-        self.mock_registry.get_registered_brokers.return_value = ["degiro"]
+        # Mock configured broker - return BrokerName enum
+        self.mock_registry.get_registered_brokers.return_value = [BrokerName.DEGIRO]
         mock_config = Mock()
         mock_config.is_enabled.return_value = True
         mock_credentials = Mock()
@@ -106,8 +107,8 @@ class TestAuthenticationMiddleware(TestCase):
         mock_resolve.return_value.url_name = "dashboard"
         mock_redirect.return_value = HttpResponse(status=302)
 
-        # Mock configured broker
-        self.mock_registry.get_registered_brokers.return_value = ["degiro"]
+        # Mock configured broker - return BrokerName enum
+        self.mock_registry.get_registered_brokers.return_value = [BrokerName.DEGIRO]
         mock_config = Mock()
         mock_config.is_enabled.return_value = True
         mock_credentials = Mock()

--- a/tests/stonks_overwatch/services/brokers/degiro/test_authentication_service.py
+++ b/tests/stonks_overwatch/services/brokers/degiro/test_authentication_service.py
@@ -9,6 +9,7 @@ from degiro_connector.core.exceptions import DeGiroConnectionError, MaintenanceE
 from django.http import HttpRequest
 
 from stonks_overwatch.config.degiro import DegiroCredentials
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.core.interfaces.authentication_service import AuthenticationResponse, AuthenticationResult
 from stonks_overwatch.services.brokers.degiro.services.authentication_service import DegiroAuthenticationService
 
@@ -43,7 +44,7 @@ class TestDegiroAuthenticationService(TestCase):
 
     def test_broker_name_property(self):
         """Test that broker_name property returns 'degiro'."""
-        assert self.auth_service.broker_name == "degiro"
+        assert self.auth_service.broker_name == BrokerName.DEGIRO
 
     def test_is_user_authenticated_valid(self):
         """Test is_user_authenticated returns True for valid authenticated user."""

--- a/tests/stonks_overwatch/services/brokers/ibkr/test_authentication_service.py
+++ b/tests/stonks_overwatch/services/brokers/ibkr/test_authentication_service.py
@@ -5,6 +5,7 @@ This module tests the IBKR authentication service implementation.
 """
 
 from stonks_overwatch.config.ibkr import IbkrConfig, IbkrCredentials
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.core.interfaces.authentication_service import (
     AuthenticationResult,
 )
@@ -48,7 +49,7 @@ class TestIbkrAuthenticationService:
 
     def test_broker_name(self):
         """Test that broker name is correctly set."""
-        assert self.service.broker_name == "ibkr"
+        assert self.service.broker_name == BrokerName.IBKR
 
     def test_validate_credentials_success(self):
         """Test successful credential validation."""
@@ -231,7 +232,7 @@ class TestIbkrAuthenticationService:
 
         status = self.service.get_authentication_status(self.request)
 
-        assert status["broker"] == "ibkr"
+        assert status["broker"] == BrokerName.IBKR
         assert status["is_authenticated"] is True
         assert status["has_session_credentials"] is True
         assert status["has_consumer_key"] is True
@@ -273,22 +274,22 @@ class TestIbkrAuthenticationServiceIntegration:
         from stonks_overwatch.core.service_types import ServiceType
 
         factory = BrokerFactory()
-        service = factory.create_service("ibkr", ServiceType.AUTHENTICATION)
+        service = factory.create_service(BrokerName.IBKR, ServiceType.AUTHENTICATION)
 
         assert service is not None
         assert isinstance(service, IbkrAuthenticationService)
-        assert service.broker_name == "ibkr"
+        assert service.broker_name == BrokerName.IBKR
 
     def test_can_be_created_directly_with_config(self):
         """Test that the service can be created directly with config."""
         from stonks_overwatch.core.factories.broker_factory import BrokerFactory
 
         factory = BrokerFactory()
-        config = factory.create_config("ibkr")
+        config = factory.create_config(BrokerName.IBKR)
 
         # Service can be instantiated directly with config
         service = IbkrAuthenticationService(config=config)
 
         assert service is not None
         assert isinstance(service, IbkrAuthenticationService)
-        assert service.broker_name == "ibkr"
+        assert service.broker_name == BrokerName.IBKR

--- a/tests/stonks_overwatch/services/test_models.py
+++ b/tests/stonks_overwatch/services/test_models.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from iso10383 import MIC
 
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.services.models import (
     AccountOverview,
     Country,
@@ -30,6 +31,48 @@ def test_portfolio_ids():
         assert as_dict["stable"] == portfolio_id.stable
 
     assert PortfolioId.from_id("XXX") == PortfolioId.ALL
+
+
+def test_portfolio_id_broker_name_property():
+    """Test that PortfolioId.broker_name returns correct BrokerName."""
+    # Broker portfolios should return their BrokerName
+    assert PortfolioId.DEGIRO.broker_name == BrokerName.DEGIRO
+    assert PortfolioId.BITVAVO.broker_name == BrokerName.BITVAVO
+    assert PortfolioId.IBKR.broker_name == BrokerName.IBKR
+
+    # ALL should return None
+    assert PortfolioId.ALL.broker_name is None
+
+
+def test_portfolio_id_from_broker_name():
+    """Test creating PortfolioId from BrokerName."""
+    assert PortfolioId.from_broker_name(BrokerName.DEGIRO) == PortfolioId.DEGIRO
+    assert PortfolioId.from_broker_name(BrokerName.BITVAVO) == PortfolioId.BITVAVO
+    assert PortfolioId.from_broker_name(BrokerName.IBKR) == PortfolioId.IBKR
+
+
+def test_portfolio_id_get_broker_portfolios():
+    """Test getting only broker portfolios (excluding ALL)."""
+    broker_portfolios = PortfolioId.get_broker_portfolios()
+
+    # Should not include ALL
+    assert PortfolioId.ALL not in broker_portfolios
+
+    # Should include all broker portfolios
+    assert PortfolioId.DEGIRO in broker_portfolios
+    assert PortfolioId.BITVAVO in broker_portfolios
+    assert PortfolioId.IBKR in broker_portfolios
+
+    # Should have exactly 3 broker portfolios
+    assert len(broker_portfolios) == 3
+
+
+def test_portfolio_id_uses_broker_name_values():
+    """Test that PortfolioId uses BrokerName as source of truth for IDs."""
+    # Verify that portfolio IDs match BrokerName values
+    assert PortfolioId.DEGIRO.id == BrokerName.DEGIRO.value
+    assert PortfolioId.BITVAVO.id == BrokerName.BITVAVO.value
+    assert PortfolioId.IBKR.id == BrokerName.IBKR.value
 
 
 def test_default_account_overview():

--- a/tests/stonks_overwatch/services/utilities/test_credential_validator.py
+++ b/tests/stonks_overwatch/services/utilities/test_credential_validator.py
@@ -1,3 +1,4 @@
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.services.utilities.credential_validator import CredentialValidator
 
 from unittest.mock import Mock
@@ -8,52 +9,52 @@ class TestCredentialValidator:
         """Test DEGIRO credential validation."""
         # Valid credentials
         valid_creds = Mock(username="myuser", password="mypassword")
-        assert CredentialValidator.has_valid_credentials("degiro", valid_creds)
+        assert CredentialValidator.has_valid_credentials(BrokerName.DEGIRO, valid_creds)
 
         # Invalid: placeholders
         placeholder_creds = Mock(username="USERNAME", password="PASSWORD")
-        assert not CredentialValidator.has_valid_credentials("degiro", placeholder_creds)
+        assert not CredentialValidator.has_valid_credentials(BrokerName.DEGIRO, placeholder_creds)
 
         # Invalid: empty
         empty_creds = Mock(username="", password="")
-        assert not CredentialValidator.has_valid_credentials("degiro", empty_creds)
+        assert not CredentialValidator.has_valid_credentials(BrokerName.DEGIRO, empty_creds)
 
         # Invalid: too short
         short_creds = Mock(username="ab", password="ab")
-        assert not CredentialValidator.has_valid_credentials("degiro", short_creds)
+        assert not CredentialValidator.has_valid_credentials(BrokerName.DEGIRO, short_creds)
 
         # Invalid: missing attributes
         missing_attr_creds = Mock()
         del missing_attr_creds.username
-        assert not CredentialValidator.has_valid_credentials("degiro", missing_attr_creds)
+        assert not CredentialValidator.has_valid_credentials(BrokerName.DEGIRO, missing_attr_creds)
 
     def test_validate_bitvavo_credentials(self):
         """Test Bitvavo credential validation."""
         # Valid credentials (length > 10)
         valid_creds = Mock(apikey="12345678901", apisecret="12345678901")
-        assert CredentialValidator.has_valid_credentials("bitvavo", valid_creds)
+        assert CredentialValidator.has_valid_credentials(BrokerName.BITVAVO, valid_creds)
 
         # Invalid: placeholders
         placeholder_creds = Mock(apikey="BITVAVO API KEY", apisecret="BITVAVO API SECRET")
-        assert not CredentialValidator.has_valid_credentials("bitvavo", placeholder_creds)
+        assert not CredentialValidator.has_valid_credentials(BrokerName.BITVAVO, placeholder_creds)
 
         # Invalid: too short
         short_creds = Mock(apikey="short", apisecret="short")
-        assert not CredentialValidator.has_valid_credentials("bitvavo", short_creds)
+        assert not CredentialValidator.has_valid_credentials(BrokerName.BITVAVO, short_creds)
 
     def test_validate_ibkr_credentials(self):
         """Test IBKR credential validation."""
         # Valid credentials (length > 10)
         valid_creds = Mock(access_token="12345678901")
-        assert CredentialValidator.has_valid_credentials("ibkr", valid_creds)
+        assert CredentialValidator.has_valid_credentials(BrokerName.IBKR, valid_creds)
 
         # Invalid: placeholders
         placeholder_creds = Mock(access_token="IBKR ACCESS TOKEN")
-        assert not CredentialValidator.has_valid_credentials("ibkr", placeholder_creds)
+        assert not CredentialValidator.has_valid_credentials(BrokerName.IBKR, placeholder_creds)
 
         # Invalid: too short
         short_creds = Mock(access_token="short")
-        assert not CredentialValidator.has_valid_credentials("ibkr", short_creds)
+        assert not CredentialValidator.has_valid_credentials(BrokerName.IBKR, short_creds)
 
     def test_unknown_broker(self):
         """Test validation for unknown broker."""
@@ -63,5 +64,5 @@ class TestCredentialValidator:
 
     def test_none_credentials(self):
         """Test validation with None credentials."""
-        assert not CredentialValidator.has_valid_credentials("degiro", None)
+        assert not CredentialValidator.has_valid_credentials(BrokerName.DEGIRO, None)
         assert not CredentialValidator.has_valid_credentials("unknown", None)

--- a/tests/stonks_overwatch/utils/core/test_session_keys.py
+++ b/tests/stonks_overwatch/utils/core/test_session_keys.py
@@ -2,6 +2,7 @@
 Unit tests for SessionKeys utility.
 """
 
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.utils.core.session_keys import SessionKeys
 
 from django.test import TestCase
@@ -12,29 +13,29 @@ class TestSessionKeys(TestCase):
 
     def test_get_authenticated_key(self):
         """Test generating authenticated session keys."""
-        assert SessionKeys.get_authenticated_key("degiro") == "degiro_authenticated"
-        assert SessionKeys.get_authenticated_key("bitvavo") == "bitvavo_authenticated"
-        assert SessionKeys.get_authenticated_key("ibkr") == "ibkr_authenticated"
+        assert SessionKeys.get_authenticated_key(BrokerName.DEGIRO) == "degiro_authenticated"
+        assert SessionKeys.get_authenticated_key(BrokerName.BITVAVO) == "bitvavo_authenticated"
+        assert SessionKeys.get_authenticated_key(BrokerName.IBKR) == "ibkr_authenticated"
         assert SessionKeys.get_authenticated_key("test_broker") == "test_broker_authenticated"
 
     def test_get_totp_required_key(self):
         """Test generating TOTP required session keys."""
-        assert SessionKeys.get_totp_required_key("degiro") == "degiro_totp_required"
-        assert SessionKeys.get_totp_required_key("bitvavo") == "bitvavo_totp_required"
+        assert SessionKeys.get_totp_required_key(BrokerName.DEGIRO) == "degiro_totp_required"
+        assert SessionKeys.get_totp_required_key(BrokerName.BITVAVO) == "bitvavo_totp_required"
         assert SessionKeys.get_totp_required_key("test_broker") == "test_broker_totp_required"
 
     def test_get_in_app_auth_required_key(self):
         """Test generating in-app auth required session keys."""
-        assert SessionKeys.get_in_app_auth_required_key("degiro") == "degiro_in_app_auth_required"
-        assert SessionKeys.get_in_app_auth_required_key("bitvavo") == "bitvavo_in_app_auth_required"
+        assert SessionKeys.get_in_app_auth_required_key(BrokerName.DEGIRO) == "degiro_in_app_auth_required"
+        assert SessionKeys.get_in_app_auth_required_key(BrokerName.BITVAVO) == "bitvavo_in_app_auth_required"
         assert SessionKeys.get_in_app_auth_required_key("test_broker") == "test_broker_in_app_auth_required"
 
     def test_get_credentials_key(self):
         """Test generating credentials session keys."""
         # Special case for degiro
-        assert SessionKeys.get_credentials_key("degiro") == "degiro_credentials"
+        assert SessionKeys.get_credentials_key(BrokerName.DEGIRO) == "degiro_credentials"
 
         # Standard format for others
-        assert SessionKeys.get_credentials_key("bitvavo") == "bitvavo_credentials"
-        assert SessionKeys.get_credentials_key("ibkr") == "ibkr_credentials"
+        assert SessionKeys.get_credentials_key(BrokerName.BITVAVO) == "bitvavo_credentials"
+        assert SessionKeys.get_credentials_key(BrokerName.IBKR) == "ibkr_credentials"
         assert SessionKeys.get_credentials_key("test_broker") == "test_broker_credentials"

--- a/tests/stonks_overwatch/views/test_broker_login.py
+++ b/tests/stonks_overwatch/views/test_broker_login.py
@@ -7,6 +7,7 @@ for different brokers (DEGIRO, Bitvavo, IBKR).
 
 from django.contrib.sessions.backends.db import SessionStore
 
+from stonks_overwatch.constants import BrokerName
 from stonks_overwatch.core.interfaces.authentication_service import AuthenticationResponse, AuthenticationResult
 from stonks_overwatch.views.broker_login import BrokerLogin
 
@@ -44,7 +45,11 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["degiro", "bitvavo", "ibkr"]
+        mock_registry.get_registered_brokers.return_value = [
+            BrokerName.DEGIRO.value,
+            BrokerName.BITVAVO.value,
+            BrokerName.IBKR.value,
+        ]
 
         # Mock config
         mock_config = Mock()
@@ -71,7 +76,11 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["degiro", "bitvavo", "ibkr"]
+        mock_registry.get_registered_brokers.return_value = [
+            BrokerName.DEGIRO.value,
+            BrokerName.BITVAVO.value,
+            BrokerName.IBKR.value,
+        ]
 
         # Mock config
         mock_config = Mock()
@@ -98,7 +107,11 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation - invalid broker not in list
-        mock_registry.get_registered_brokers.return_value = ["degiro", "bitvavo", "ibkr"]
+        mock_registry.get_registered_brokers.return_value = [
+            BrokerName.DEGIRO.value,
+            BrokerName.BITVAVO.value,
+            BrokerName.IBKR.value,
+        ]
 
         request = self.factory.get("/login/invalid/")
         request.session = self.session
@@ -121,7 +134,7 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["degiro"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.DEGIRO.value]
 
         request = self.factory.post("/login/degiro/", {"update_portfolio": "true"})
         request.session = self.session
@@ -146,7 +159,7 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["degiro"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.DEGIRO.value]
 
         # Mock config
         mock_config = Mock()
@@ -183,7 +196,7 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["bitvavo"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.BITVAVO.value]
 
         # Mock config
         mock_config = Mock()
@@ -228,7 +241,7 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["bitvavo"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.BITVAVO.value]
 
         # Mock config
         mock_config = Mock()
@@ -261,7 +274,7 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["degiro"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.DEGIRO.value]
 
         # Mock config
         mock_config = Mock()
@@ -299,7 +312,7 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["degiro"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.DEGIRO.value]
 
         # Mock config
         mock_config = Mock()
@@ -343,7 +356,7 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["degiro"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.DEGIRO.value]
 
         # Mock config
         mock_config = Mock()
@@ -379,7 +392,7 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["degiro"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.DEGIRO.value]
 
         request = self.factory.post("/login/degiro/", {})
         request.session = self.session
@@ -392,16 +405,24 @@ class TestBrokerLoginView(TestCase):
         call_args = mock_messages.call_args[0]
         assert "required" in call_args[1].lower()
 
-    def test_get_display_name(self):
-        """Test _get_display_name returns correct display names."""
-        assert self.view._get_display_name("degiro") == "DEGIRO"
-        assert self.view._get_display_name("bitvavo") == "Bitvavo"
-        assert self.view._get_display_name("ibkr") == "Interactive Brokers"
-        assert self.view._get_display_name("unknown") == "Unknown"
+    def test_broker_display_names(self):
+        """Test BrokerName enum provides correct display names."""
+        assert BrokerName.DEGIRO.display_name == "DEGIRO"
+        assert BrokerName.BITVAVO.display_name == "Bitvavo"
+        assert BrokerName.IBKR.display_name == "Interactive Brokers"
+        # Also test short names
+        assert BrokerName.IBKR.short_name == "IBKR"
+        assert BrokerName.DEGIRO.short_name == "DEGIRO"
+        # Test __repr__() for debugging
+        assert repr(BrokerName.DEGIRO) == "BrokerName.DEGIRO"
+        assert repr(BrokerName.IBKR) == "BrokerName.IBKR"
+        # Test __str__() returns value
+        assert str(BrokerName.DEGIRO) == "degiro"
+        assert str(BrokerName.IBKR) == "ibkr"
 
     def test_get_auth_fields_degiro(self):
         """Test _get_auth_fields returns correct fields for DEGIRO."""
-        fields = self.view._get_auth_fields("degiro")
+        fields = self.view._get_auth_fields(BrokerName.DEGIRO)
         assert fields["username_label"] == "Username"
         assert fields["password_label"] == "Password"
         assert fields["supports_2fa"] is True
@@ -409,7 +430,7 @@ class TestBrokerLoginView(TestCase):
 
     def test_get_auth_fields_bitvavo(self):
         """Test _get_auth_fields returns correct fields for Bitvavo."""
-        fields = self.view._get_auth_fields("bitvavo")
+        fields = self.view._get_auth_fields(BrokerName.BITVAVO)
         assert fields["username_label"] == "API Key"
         assert fields["password_label"] == "API Secret"
         assert fields["supports_2fa"] is False
@@ -417,7 +438,7 @@ class TestBrokerLoginView(TestCase):
 
     def test_get_auth_fields_ibkr(self):
         """Test _get_auth_fields returns correct fields for IBKR."""
-        fields = self.view._get_auth_fields("ibkr")
+        fields = self.view._get_auth_fields(BrokerName.IBKR)
         assert fields["access_token_label"] == "Access Token"
         assert fields["access_token_secret_label"] == "Access Token Secret"
         assert fields["consumer_key_label"] == "Consumer Key"
@@ -539,7 +560,7 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["degiro"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.DEGIRO.value]
 
         # Mock config
         mock_config = Mock()
@@ -569,7 +590,7 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["degiro"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.DEGIRO.value]
 
         # Mock config
         mock_config = Mock()
@@ -608,7 +629,7 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["degiro"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.DEGIRO.value]
 
         # Mock config
         mock_config = Mock()
@@ -647,7 +668,7 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["degiro"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.DEGIRO.value]
 
         # Mock config
         mock_config = Mock()
@@ -712,7 +733,7 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["degiro"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.DEGIRO.value]
 
         # Mock config
         mock_config = Mock()
@@ -754,7 +775,7 @@ class TestBrokerLoginView(TestCase):
         mock_config = Mock()
 
         mock_factory.create_config.return_value = mock_config
-        mock_registry.get_registered_brokers.return_value = ["ibkr"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.IBKR.value]
 
         self.view.factory = mock_factory
         self.view.registry = mock_registry
@@ -794,7 +815,7 @@ class TestBrokerLoginView(TestCase):
         mock_config = Mock()
 
         mock_factory.create_config.return_value = mock_config
-        mock_registry.get_registered_brokers.return_value = ["ibkr"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.IBKR.value]
 
         self.view.factory = mock_factory
         self.view.registry = mock_registry
@@ -834,7 +855,7 @@ class TestBrokerLoginView(TestCase):
 
         # Mock the registry
         mock_registry = Mock()
-        mock_registry.get_registered_brokers.return_value = ["ibkr"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.IBKR.value]
         self.view.registry = mock_registry
 
         # Test missing credentials (empty required fields)
@@ -866,7 +887,7 @@ class TestBrokerLoginView(TestCase):
         mock_factory_class.return_value = mock_factory
 
         # Mock broker validation
-        mock_registry.get_registered_brokers.return_value = ["bitvavo"]
+        mock_registry.get_registered_brokers.return_value = [BrokerName.BITVAVO.value]
 
         # Mock config
         mock_config = Mock()
@@ -898,12 +919,12 @@ class TestBrokerLoginView(TestCase):
         request.session = self.session
         request.session["degiro_totp_required"] = True
 
-        result = self.view._check_totp_required(request, "degiro")
+        result = self.view._check_totp_required(request, BrokerName.DEGIRO)
         assert result is True
 
         # Test without session flag
         request.session["degiro_totp_required"] = False
-        result = self.view._check_totp_required(request, "degiro")
+        result = self.view._check_totp_required(request, BrokerName.DEGIRO)
         assert result is False
 
     def test_check_totp_required_other_brokers(self):
@@ -911,10 +932,10 @@ class TestBrokerLoginView(TestCase):
         request = self.factory.get("/login/bitvavo/")
         request.session = self.session
 
-        result = self.view._check_totp_required(request, "bitvavo")
+        result = self.view._check_totp_required(request, BrokerName.BITVAVO)
         assert result is False
 
-        result = self.view._check_totp_required(request, "ibkr")
+        result = self.view._check_totp_required(request, BrokerName.IBKR)
         assert result is False
 
     def test_check_in_app_auth_required_degiro(self):
@@ -923,12 +944,12 @@ class TestBrokerLoginView(TestCase):
         request.session = self.session
         request.session["degiro_in_app_auth_required"] = True
 
-        result = self.view._check_in_app_auth_required(request, "degiro")
+        result = self.view._check_in_app_auth_required(request, BrokerName.DEGIRO)
         assert result is True
 
         # Test without session flag
         request.session["degiro_in_app_auth_required"] = False
-        result = self.view._check_in_app_auth_required(request, "degiro")
+        result = self.view._check_in_app_auth_required(request, BrokerName.DEGIRO)
         assert result is False
 
     def test_check_in_app_auth_required_other_brokers(self):
@@ -936,10 +957,10 @@ class TestBrokerLoginView(TestCase):
         request = self.factory.get("/login/bitvavo/")
         request.session = self.session
 
-        result = self.view._check_in_app_auth_required(request, "bitvavo")
+        result = self.view._check_in_app_auth_required(request, BrokerName.BITVAVO)
         assert result is False
 
-        result = self.view._check_in_app_auth_required(request, "ibkr")
+        result = self.view._check_in_app_auth_required(request, BrokerName.IBKR)
         assert result is False
 
     def test_check_authenticated(self):
@@ -949,20 +970,20 @@ class TestBrokerLoginView(TestCase):
 
         # Test DEGIRO
         request.session["degiro_authenticated"] = True
-        result = self.view._check_authenticated(request, "degiro")
+        result = self.view._check_authenticated(request, BrokerName.DEGIRO)
         assert result is True
 
         # Test Bitvavo
         request.session["bitvavo_authenticated"] = True
-        result = self.view._check_authenticated(request, "bitvavo")
+        result = self.view._check_authenticated(request, BrokerName.BITVAVO)
         assert result is True
 
         # Test IBKR
         request.session["ibkr_authenticated"] = True
-        result = self.view._check_authenticated(request, "ibkr")
+        result = self.view._check_authenticated(request, BrokerName.BITVAVO)
         assert result is True
 
         # Test without authentication
         request.session.clear()
-        result = self.view._check_authenticated(request, "degiro")
+        result = self.view._check_authenticated(request, BrokerName.DEGIRO)
         assert result is False


### PR DESCRIPTION
# Pull Request

## Description

Replace hardcoded "degiro", "bitvavo", and "ibkr" strings throughout the codebase with type-safe BrokerName enum constants. This improves type safety, enables better IDE autocomplete, and eliminates potential typo bugs.

## Type

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [x] 🔧 Refactoring
- [ ] 🏦 Broker integration
- [ ] 🎨 UI/UX

---

✅ **Checklist:** Read [CONTRIBUTING](../CONTRIBUTING.md), tests pass, code formatted, docs updated

**Thank you for contributing!** 🎉
