### PR TITLE
fix: Ensure timezone-aware datetime usage throughout codebase

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,15 +119,16 @@ target-version = "py313"
 
 [tool.ruff.lint]
 select = [
-    "C",  # pylint convention
-    "E",  # pycodestyle errors
-    "W",  # pycodestyle warnings
-    "F",  # pyflakes
-    "I",  # isort
-    "B",  # flake8-bugbear
-    "C4", # flake8-comprehensions
-    "N",  # PEP8 naming conventions
-    "W",  # pylint warning
+    "C",   # pylint convention
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "N",   # PEP8 naming conventions
+    "W",   # pylint warning
+    "DTZ", # flake8-datetimez (prevent naive datetime usage)
 ]
 ignore = []
 
@@ -137,6 +138,11 @@ unfixable = []
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore timezone-awareness rules in tests and scripts (they don't interact with Django models)
+"tests/**/*.py" = ["DTZ"]
+"scripts/**/*.py" = ["DTZ"]
 
 [tool.ruff.lint.isort]
 order-by-type = true

--- a/src/stonks_overwatch/jobs/jobs_scheduler.py
+++ b/src/stonks_overwatch/jobs/jobs_scheduler.py
@@ -1,7 +1,6 @@
-from datetime import datetime
-
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
+from django.utils import timezone
 
 from stonks_overwatch.constants.brokers import BrokerName
 from stonks_overwatch.core.exceptions import CredentialsException
@@ -147,7 +146,7 @@ class JobsScheduler:
             JobsScheduler._configure_jobs,
             id="configure_jobs",
             trigger="date",
-            run_date=datetime.now(),
+            run_date=timezone.now(),
             max_instances=1,
             replace_existing=True,
         )
@@ -185,7 +184,7 @@ class JobsScheduler:
                     trigger=IntervalTrigger(minutes=config.update_frequency_minutes),
                     max_instances=1,
                     replace_existing=True,
-                    next_run_time=datetime.now(),
+                    next_run_time=timezone.now(),
                 ),
             )
 

--- a/src/stonks_overwatch/middleware/error_handler.py
+++ b/src/stonks_overwatch/middleware/error_handler.py
@@ -1,9 +1,9 @@
 import traceback
-from datetime import datetime
 
 from django.conf import settings
 from django.http import HttpResponseServerError
 from django.shortcuts import render
+from django.utils import timezone
 from django.utils.deprecation import MiddlewareMixin
 
 
@@ -33,7 +33,7 @@ class CustomErrorHandlerMiddleware(MiddlewareMixin):
             "support_url": support_url,
             # Only include traceback in development
             "traceback": traceback.format_exc() if settings.DEBUG else None,
-            "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "timestamp": timezone.now().strftime("%Y-%m-%d %H:%M:%S"),
         }
 
         try:

--- a/src/stonks_overwatch/services/brokers/bitvavo/client/bitvavo_client.py
+++ b/src/stonks_overwatch/services/brokers/bitvavo/client/bitvavo_client.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone as dt_timezone
 from typing import Any, Optional
 
 from python_bitvavo_api.bitvavo import Bitvavo, createPostfix
@@ -132,7 +132,7 @@ class BitvavoService:
         for candle in response:
             result.append(
                 {
-                    "timestamp": datetime.fromtimestamp(candle[0] / 1000),
+                    "timestamp": datetime.fromtimestamp(candle[0] / 1000, tz=dt_timezone.utc),
                     "open": candle[1],
                     "high": candle[2],
                     "low": candle[3],

--- a/src/stonks_overwatch/services/brokers/bitvavo/services/account_service.py
+++ b/src/stonks_overwatch/services/brokers/bitvavo/services/account_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone as dt_timezone
 from typing import List, Optional
 
 from stonks_overwatch.config.base_config import BaseConfig
@@ -55,7 +55,7 @@ class AccountOverviewService(AccountServiceInterface, BaseService):
         """
         Parses a date time string to datetime object.
         """
-        return datetime.strptime(value, AccountOverviewService.TIME_DATE_FORMAT)
+        return datetime.strptime(value, AccountOverviewService.TIME_DATE_FORMAT).replace(tzinfo=dt_timezone.utc)
 
     @staticmethod
     def __get_description(item: dict) -> str:

--- a/src/stonks_overwatch/services/brokers/bitvavo/services/deposit_service.py
+++ b/src/stonks_overwatch/services/brokers/bitvavo/services/deposit_service.py
@@ -1,5 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone as dt_timezone
 from typing import List, Optional
+
+from django.utils import timezone as django_timezone
 
 from stonks_overwatch.config.base_config import BaseConfig
 from stonks_overwatch.core.interfaces.base_service import BaseService
@@ -31,7 +33,7 @@ class DepositsService(BaseService, DepositServiceInterface):
             amount = float(entry["amount"])
             history.append(
                 Deposit(
-                    datetime=datetime.fromtimestamp(entry["timestamp"] / 1000),
+                    datetime=datetime.fromtimestamp(entry["timestamp"] / 1000, tz=dt_timezone.utc),
                     type=DepositType.DEPOSIT,
                     change=amount,
                     currency=entry["symbol"],
@@ -43,7 +45,7 @@ class DepositsService(BaseService, DepositServiceInterface):
             amount = float(entry["amount"])
             history.append(
                 Deposit(
-                    datetime=datetime.fromtimestamp(entry["timestamp"] / 1000),
+                    datetime=datetime.fromtimestamp(entry["timestamp"] / 1000, tz=dt_timezone.utc),
                     type=DepositType.WITHDRAWAL,
                     change=-amount,
                     currency=entry["symbol"],
@@ -70,7 +72,7 @@ class DepositsService(BaseService, DepositServiceInterface):
 
         # Convert string dates to datetime objects for manipulation
         start_date = datetime.fromisoformat(sorted(sorted_data.keys())[0])
-        end_date = datetime.today()
+        end_date = django_timezone.now()
 
         # Iterate over the full date range
         current_date = start_date

--- a/src/stonks_overwatch/services/brokers/bitvavo/services/portfolio_service.py
+++ b/src/stonks_overwatch/services/brokers/bitvavo/services/portfolio_service.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone as dt_timezone
 from typing import List, Optional
+
+from django.utils import timezone
 
 from stonks_overwatch.config.base_config import BaseConfig
 from stonks_overwatch.core.interfaces import PortfolioServiceInterface
@@ -178,7 +180,7 @@ class PortfolioService(BaseService, PortfolioServiceInterface):
         if date_str == 0:
             return LocalizationUtility.convert_string_to_date(date_str)
         else:
-            return datetime.today().date()
+            return timezone.now().date()
 
     def _calculate_position_growth(self, entry: dict) -> dict:
         product_history_dates = list(entry["history"].keys())
@@ -311,7 +313,7 @@ class PortfolioService(BaseService, PortfolioServiceInterface):
     @staticmethod
     def _is_weekend(date_str: str) -> bool:
         # Parse the date string into a datetime object
-        day = datetime.strptime(date_str, "%Y-%m-%d")
+        day = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=dt_timezone.utc)
         # Check if the day of the week is Saturday (5) or Sunday (6)
         return day.weekday() >= 5
 

--- a/src/stonks_overwatch/services/brokers/bitvavo/services/transaction_service.py
+++ b/src/stonks_overwatch/services/brokers/bitvavo/services/transaction_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone as dt_timezone
 from typing import List, Optional
 
 from stonks_overwatch.config.base_config import BaseConfig
@@ -78,7 +78,7 @@ class TransactionsService(BaseService, TransactionServiceInterface):
         Parses a date time string to a datetime object.
         """
         try:
-            return datetime.strptime(value, TransactionsService.TIME_DATE_FORMAT)
+            return datetime.strptime(value, TransactionsService.TIME_DATE_FORMAT).replace(tzinfo=dt_timezone.utc)
         except ValueError as e:
             raise ValueError(
                 f"Invalid date format: {value}. Expected format is {TransactionsService.TIME_DATE_FORMAT}."

--- a/src/stonks_overwatch/services/brokers/bitvavo/services/update_service.py
+++ b/src/stonks_overwatch/services/brokers/bitvavo/services/update_service.py
@@ -1,8 +1,9 @@
 import os
-from datetime import date, timedelta
+from datetime import timedelta
 from typing import Optional
 
 from degiro_connector.quotecast.models.chart import Interval
+from django.utils import timezone
 
 from stonks_overwatch.config.bitvavo import BitvavoConfig
 from stonks_overwatch.constants import BrokerName
@@ -103,7 +104,7 @@ class UpdateService(BaseService, AbstractUpdateService):
         product_growth = self.portfolio_data.calculate_product_growth()
 
         delete_keys = []
-        today = LocalizationUtility.format_date_from_date(date.today())
+        today = LocalizationUtility.format_date_from_date(timezone.now().date())
 
         for key in product_growth.keys():
             # Calculate Quotation Range
@@ -148,7 +149,9 @@ class UpdateService(BaseService, AbstractUpdateService):
     def _create_products_quotation(self, symbol: str, data: dict) -> dict:
         product_history_dates = list(data["history"].keys())
 
-        start_date = LocalizationUtility.convert_string_to_datetime(product_history_dates[0])
+        start_date = LocalizationUtility.ensure_aware(
+            LocalizationUtility.convert_string_to_datetime(product_history_dates[0])
+        )
         candles = self.bitvavo_service.candles(f"{symbol}-{self.currency}", "1d", start_date)
         # Creates the dictionary with the date as key and the value as the close price
         date_to_value = {

--- a/src/stonks_overwatch/services/brokers/degiro/client/degiro_client.py
+++ b/src/stonks_overwatch/services/brokers/degiro/client/degiro_client.py
@@ -1,5 +1,5 @@
 import os
-from datetime import date, datetime, timedelta
+from datetime import timedelta
 from typing import Any, List, Optional
 
 import polars as pl
@@ -10,6 +10,7 @@ from degiro_connector.quotecast.tools.chart_fetcher import ChartFetcher
 from degiro_connector.trading.api import API as TradingApi  # noqa: N811
 from degiro_connector.trading.models.agenda import AgendaRequest, CalendarType
 from degiro_connector.trading.models.credentials import Credentials
+from django.utils import timezone
 
 import stonks_overwatch.settings
 from stonks_overwatch.config.base_config import BaseConfig
@@ -346,7 +347,7 @@ class DeGiroService:
             if series.type != "time":
                 continue
 
-            current_date_str = LocalizationUtility.format_date_from_date(date.today())
+            current_date_str = LocalizationUtility.format_date_from_date(timezone.now().date())
             data_frame = pl.DataFrame(data=series.data, orient="row")
             if "column_1" in data_frame.columns:
                 quotes[current_date_str] = data_frame["column_1"][-1]
@@ -399,10 +400,10 @@ class DeGiroService:
         agenda = self.get_client().get_agenda(
             agenda_request=AgendaRequest(
                 calendar_type=CalendarType.DIVIDEND_CALENDAR,
-                start_date=datetime.now(),
+                start_date=timezone.now(),
                 # DEGIRO API seems to limit the agenda to 6 months in the future
                 #  even with that limitation doesn't show the whole agenda
-                end_date=datetime.now() + timedelta(days=180),
+                end_date=timezone.now() + timedelta(days=180),
                 offset=0,
                 limit=25,
                 isin=isin,

--- a/src/stonks_overwatch/services/brokers/degiro/services/dividend_service.py
+++ b/src/stonks_overwatch/services/brokers/degiro/services/dividend_service.py
@@ -1,6 +1,8 @@
 from datetime import datetime, time
 from typing import List, Optional
 
+from django.utils import timezone
+
 from stonks_overwatch.config.base_config import BaseConfig
 from stonks_overwatch.core.interfaces.base_service import BaseService
 from stonks_overwatch.core.interfaces.dividend_service import DividendServiceInterface
@@ -197,7 +199,7 @@ class DividendsService(BaseService, DividendServiceInterface):
 
                     if (
                         forecasted_dividends["exDividendDate"]
-                        and forecasted_dividends["exDividendDate"].date() > datetime.now().date()
+                        and forecasted_dividends["exDividendDate"].date() > timezone.now().date()
                     ):
                         result.append(
                             Dividend(

--- a/src/stonks_overwatch/services/brokers/degiro/services/portfolio_service.py
+++ b/src/stonks_overwatch/services/brokers/degiro/services/portfolio_service.py
@@ -1,8 +1,9 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone as dt_timezone
 from typing import List, Optional
 from zoneinfo import ZoneInfo
 
 from degiro_connector.trading.models.account import UpdateOption, UpdateRequest
+from django.utils import timezone
 from django.utils.functional import cached_property
 from iso10383 import MIC
 
@@ -548,7 +549,7 @@ class PortfolioService(BaseService, PortfolioServiceInterface):
         if date_str == 0:
             return LocalizationUtility.convert_string_to_date(date_str)
         else:
-            return datetime.today().date()
+            return timezone.now().date()
 
     def _calculate_position_growth(self, entry: dict) -> dict:
         """Calculate position growth with stock split adjustments."""
@@ -784,6 +785,6 @@ class PortfolioService(BaseService, PortfolioServiceInterface):
     @staticmethod
     def _is_weekend(date_str: str):
         # Parse the date string into a datetime object
-        day = datetime.strptime(date_str, "%Y-%m-%d")
+        day = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=dt_timezone.utc)
         # Check if the day of the week is Saturday (5) or Sunday (6)
         return day.weekday() >= 5

--- a/src/stonks_overwatch/services/brokers/ibkr/services/portfolio.py
+++ b/src/stonks_overwatch/services/brokers/ibkr/services/portfolio.py
@@ -1,7 +1,7 @@
 import time
-from datetime import datetime
 from typing import List, Optional
 
+from django.utils import timezone
 from django.utils.functional import cached_property
 from iso10383 import MIC
 
@@ -278,7 +278,7 @@ class PortfolioService(BaseService, PortfolioServiceInterface):
         try:
             # Get current portfolio total
             portfolio_total = self.get_portfolio_total()
-            current_date = datetime.now().strftime("%Y-%m-%d")
+            current_date = timezone.now().strftime("%Y-%m-%d")
 
             # Return minimal historical data with current value
             return [DailyValue(x=current_date, y=portfolio_total.current_value)]

--- a/src/stonks_overwatch/utils/core/datetime.py
+++ b/src/stonks_overwatch/utils/core/datetime.py
@@ -2,6 +2,7 @@ from datetime import date, timedelta
 from typing import Optional
 
 from degiro_connector.quotecast.models.chart import Interval
+from django.utils import timezone
 
 
 class DateTimeUtility:
@@ -22,7 +23,7 @@ class DateTimeUtility:
                                 Returns None if the date_from is invalid or in the future.
         """
         d1 = date.fromisoformat(date_from)
-        today = date.today()
+        today = timezone.now().date()
 
         if d1 > today:
             return None
@@ -98,6 +99,6 @@ class DateTimeUtility:
             case Interval.P50Y:
                 return 50 * 365
             case Interval.YTD:
-                return (date.today() - date(date.today().year, 1, 1)).days
+                return (timezone.now().date() - date(timezone.now().date().year, 1, 1)).days
             case _:
                 raise ValueError(f"Invalid interval: {interval}")

--- a/src/stonks_overwatch/utils/core/localization.py
+++ b/src/stonks_overwatch/utils/core/localization.py
@@ -1,5 +1,5 @@
 import calendar
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timezone as dt_timezone
 from typing import Optional
 
 from currency_symbols import CurrencySymbols
@@ -30,7 +30,7 @@ class LocalizationUtility:
         if isinstance(value, datetime):
             return value
         if isinstance(value, date):
-            return datetime(value.year, value.month, value.day)
+            return datetime(value.year, value.month, value.day, tzinfo=dt_timezone.utc)
         if isinstance(value, str):
             return dateutil_parser.parse(value)
         raise TypeError(f"Unsupported type: {type(value)}. Expected str, date or datetime.")
@@ -171,4 +171,4 @@ class LocalizationUtility:
 
     @staticmethod
     def now() -> datetime:
-        return datetime.now(timezone.utc)
+        return datetime.now(dt_timezone.utc)


### PR DESCRIPTION
# Pull Request

## Description

Fixes timezone-naive/aware datetime comparisons. Proactively replaces all datetime.now() usage with timezone.now() and adds linting rules to prevent future violations.

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [x] 🔧 Refactoring
- [ ] 🏦 Broker integration
- [ ] 🎨 UI/UX

---

✅ **Checklist:** Read [CONTRIBUTING](../CONTRIBUTING.md), tests pass, code formatted, docs updated

**Thank you for contributing!** 🎉
