### PR TITLE
fix: Fixed height bug with distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ _This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 
+- Distribution: Fixed bug while showing distributions at Dividends or Diversification
+
 ### Security
 
 ---

--- a/src/stonks_overwatch/staticfiles/style.css
+++ b/src/stonks_overwatch/staticfiles/style.css
@@ -1732,6 +1732,16 @@ html[style*="--sidebar-immediate-state: sidebar-collapsed"] #sidebar div.px-2.py
     overflow-y: auto;
 }
 
+/* Match list height to chart area so bars use the full vertical space */
+.distribution-with-list .diversification-chart-container {
+    height: 100%;
+}
+
+.distribution-with-list .diversification-scrollable-list {
+    max-height: min(40vw, 40vh, 400px);
+    align-self: stretch;
+}
+
 .diversification-weight {
     position: relative;
     z-index: 1;

--- a/src/stonks_overwatch/templates/components/distribution_with_list.html
+++ b/src/stonks_overwatch/templates/components/distribution_with_list.html
@@ -1,5 +1,5 @@
 <div
-    class="row align-items-stretch w-100 {% if show_border != False %}diversification-card rounded mb-3{% else %}mx-0{% endif %} pb-3">
+    class="row distribution-with-list align-items-stretch w-100 {% if show_border != False %}diversification-card rounded mb-3{% else %}mx-0{% endif %} pb-3">
     <div class="col-sm diversification-chart-container">
         <canvas id="{{ chart_id }}"></canvas>
     </div>


### PR DESCRIPTION
# Pull Request

## Description

While visualizing distributions at Diversification or Dividends views, the lists were not shown properly. Not the lists are using 100% of the available height.

## Type

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactoring
- [ ] 🏦 Broker integration
- [x] 🎨 UI/UX

---

✅ **Checklist:** Read [CONTRIBUTING](../CONTRIBUTING.md), tests pass, code formatted, docs updated

**Thank you for contributing!** 🎉
