### PR TITLE
chore: autoupdate pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.4
+    rev: v0.15.5
     hooks:
       # Run the linter
       - id: ruff


### PR DESCRIPTION
This PR updates pre-commit hooks to their latest versions.

Changes made by `pre-commit autoupdate`.

Please review the changes before merging.