### PR TITLE
fix: redact credentials in DB dump by default, preserve on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ _This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) a
   - Handle incomplete IBKR API contract data with defensive fallbacks
   - Fixed portfolio API import. Improves identification of ETFs
   - Retrieve asset logos directly from IBKR using the contract ID (conid)
+- DB Dump: Credentials are redacted by default; use `--include-credentials` to include them. When loading a redacted
+dump, existing credentials are preserved
 
 ### Security
 

--- a/scripts/dump_db.py
+++ b/scripts/dump_db.py
@@ -25,8 +25,9 @@ from scripts.common import setup_script_environment
 # Set up Django environment and logging
 setup_script_environment()
 
+from stonks_overwatch.services.brokers.models import BrokersConfiguration  # noqa: E402
 from stonks_overwatch.settings import DATABASES  # noqa: E402
-from stonks_overwatch.utils.database.db_utils import dump_database  # noqa: E402
+from stonks_overwatch.utils.database.db_utils import are_credentials_redacted, dump_database  # noqa: E402
 
 
 def load_database(input_file, database="default"):
@@ -76,6 +77,10 @@ def load_database(input_file, database="default"):
         objects_loaded = 0
         with transaction.atomic(using=database):
             for obj in serializers.deserialize("json", data):
+                instance = obj.object
+                if isinstance(instance, BrokersConfiguration) and are_credentials_redacted(instance.credentials):
+                    existing = BrokersConfiguration.objects.using(database).filter(pk=instance.pk).first()
+                    instance.credentials = existing.credentials if existing else {}
                 obj.save(using=database)
                 objects_loaded += 1
 
@@ -100,6 +105,12 @@ def main():
         choices=["default", "demo"],
         help="Database to use (default: default, options: default, demo)",
     )
+    dump_parser.add_argument(
+        "--include-credentials",
+        action="store_true",
+        default=False,
+        help="Include actual credential values in the dump (default: redacted)",
+    )
 
     # Load command
     load_parser = subparsers.add_parser("load", help="Load database from file")
@@ -119,7 +130,7 @@ def main():
         return
 
     if args.command == "dump":
-        dump_database(output_file=args.output, database=args.database)
+        dump_database(output_file=args.output, database=args.database, include_credentials=args.include_credentials)
     elif args.command == "load":
         load_database(input_file=args.input, database=args.database)
 

--- a/src/stonks_overwatch/utils/database/db_utils.py
+++ b/src/stonks_overwatch/utils/database/db_utils.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import zipfile
 
@@ -62,7 +63,29 @@ def get_models():
     return models
 
 
-def dump_database(output_file="db_dump.zip", database="default"):
+def _redact_credentials(obj):
+    """Return a copy of a BrokersConfiguration instance with credential values redacted.
+
+    Each credential key is kept, but its value is replaced with a boolean
+    indicating whether the original value was non-empty.
+    """
+    from stonks_overwatch.services.brokers.models import BrokersConfiguration
+
+    if not isinstance(obj, BrokersConfiguration):
+        return obj
+
+    redacted = copy.copy(obj)
+    if redacted.credentials:
+        redacted.credentials = {key: bool(value) for key, value in redacted.credentials.items()}
+    return redacted
+
+
+def are_credentials_redacted(credentials: dict) -> bool:
+    """Return True if all credential values are booleans, indicating a redacted dump."""
+    return bool(credentials) and all(isinstance(v, bool) for v in credentials.values())
+
+
+def dump_database(output_file="db_dump.zip", database="default", include_credentials=False):
     """Dump database content to JSON file"""
 
     if database == "demo":
@@ -74,7 +97,10 @@ def dump_database(output_file="db_dump.zip", database="default"):
     objects_to_serialize = []
     for model in get_models():
         objects = model.objects.all()
-        objects_to_serialize.extend(objects)
+        if include_credentials:
+            objects_to_serialize.extend(objects)
+        else:
+            objects_to_serialize.extend(_redact_credentials(obj) for obj in objects)
         print(f"Found {objects.count()} objects in {model._meta.app_label}.{model._meta.model_name}")
 
     # Serialize to JSON


### PR DESCRIPTION
# Pull Request

## Description

Credentials are now redacted by default when dumping the database, replacing each value with a boolean indicating if it was set. Pass --include-credentials to include the actual values. When loading a redacted dump, existing credentials in the target database are preserved instead of being overwritten with placeholders.

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactoring
- [ ] 🏦 Broker integration
- [ ] 🎨 UI/UX

---

✅ **Checklist:** Read [CONTRIBUTING](../CONTRIBUTING.md), tests pass, code formatted, docs updated

**Thank you for contributing!** 🎉
