### PR TITLE
ci: fix GitHub Actions configuration issues

### DIFF
--- a/.github/actions/common-action/action.yml
+++ b/.github/actions/common-action/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.local
-        key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+        key: ${{ runner.os }}-poetry
     #----------------------------------------------
     #  -----  install & configure poetry  -----
     #----------------------------------------------

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "deps"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/common-action"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "pre-commit"
     directory: "/"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -108,6 +108,8 @@ jobs:
     name: Release Packages
     needs: package
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# Pull Request

## Description

- Add Dependabot coverage for composite action in .github/actions/common-action
- Add missing commit-message prefix and open-pull-requests-limit to github-actions Dependabot entry
- Fix Poetry binary cache key to not depend on poetry.lock hash
- Add explicit contents: write permission to release job in package.yml

---

✅ **Checklist:** Read [CONTRIBUTING](../CONTRIBUTING.md), tests pass, code formatted, docs updated

**Thank you for contributing!** 🎉
