### PR TITLE
fix: Fixed bug in Alpaca

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,7 +298,11 @@ dump, existing credentials are preserved
 ---
 
 <!-- Version Comparison Links -->
-[Unreleased]: https://github.com/ctasada/stonks-overwatch/compare/v0.1.5...HEAD
+[Unreleased]: https://github.com/ctasada/stonks-overwatch/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/ctasada/stonks-overwatch/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/ctasada/stonks-overwatch/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/ctasada/stonks-overwatch/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/ctasada/stonks-overwatch/compare/v0.1.5...v0.2.0
 [0.1.5]: https://github.com/ctasada/stonks-overwatch/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/ctasada/stonks-overwatch/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/ctasada/stonks-overwatch/compare/v0.1.2...v0.1.3

--- a/docs/Alpaca.md
+++ b/docs/Alpaca.md
@@ -353,7 +353,7 @@ The database models are defined in:
 │                  Stonks Overwatch                       │
 │                                                         │
 │  PortfolioService  TransactionService  DividendService  │
-│  DepositService    AccountService      UpdateService     │
+│  DepositService    AccountService      UpdateService    │
 │         │                │                  │           │
 │         └────────────────┼──────────────────┘           │
 │                          │                              │
@@ -361,10 +361,10 @@ The database models are defined in:
 └──────────────┬───────────┴───────────────┬──────────────┘
                │                           │
       ┌────────▼────────┐        ┌─────────▼─────────┐
-      │  alpaca-py SDK  │        │   Raw HTTP         │
-      │  TradingClient  │        │   /v2/account/     │
-      │  DataClient     │        │   activities       │
-      └────────┬────────┘        └─────────┬──────────┘
+      │  alpaca-py SDK  │        │   Raw HTTP        │
+      │  TradingClient  │        │   /v2/account/    │
+      │  DataClient     │        │   activities      │
+      └────────┬────────┘        └─────────┬─────────┘
                │                           │
                └──────────┬────────────────┘
                           │ HTTPS

--- a/src/stonks_overwatch/services/aggregators/portfolio_aggregator.py
+++ b/src/stonks_overwatch/services/aggregators/portfolio_aggregator.py
@@ -41,10 +41,19 @@ class PortfolioAggregatorService(BaseAggregator):
 
     def _fill_missing_entry_info(self, portfolio: List[PortfolioEntry]):
         for entry in portfolio:
+            self._assign_name(entry)
             self._assign_country(entry)
             self._assign_sector(entry)
             self._assign_industry(entry)
             self._warn_if_unknown_sector(entry)
+
+    def _assign_name(self, entry: PortfolioEntry):
+        if entry.product_type not in (ProductType.STOCK, ProductType.ETF):
+            return
+        if not entry.name or entry.name == entry.symbol:
+            name = self.yfinance.get_name(entry.symbol)
+            if name:
+                entry.name = name
 
     def _assign_country(self, entry: PortfolioEntry):
         if not entry.country and entry.product_type in [ProductType.STOCK, ProductType.ETF]:

--- a/src/stonks_overwatch/services/brokers/yfinance/services/market_data_service.py
+++ b/src/stonks_overwatch/services/brokers/yfinance/services/market_data_service.py
@@ -115,6 +115,24 @@ class YFinance:
 
         return None
 
+    def get_name(self, symbol: str) -> str | None:
+        """
+        Get the full company name for a ticker symbol.
+
+        Prefers ``longName`` (e.g. "Apple Inc.") and falls back to
+        ``shortName`` (e.g. "Apple") when the long name is unavailable.
+
+        Args:
+            symbol: Stock ticker symbol
+
+        Returns:
+            Company name string, or None if not found
+        """
+        ticker_info = self._get_ticker_info_with_retry(symbol)
+        if ticker_info is None:
+            return None
+        return ticker_info.get("longName") or ticker_info.get("shortName") or None
+
     def get_sector_industry(self, symbol: str) -> tuple[Sector, str | None]:
         """
         Get sector and industry information for a ticker symbol.

--- a/tests/stonks_overwatch/services/aggregators/test_portfolio_aggregator.py
+++ b/tests/stonks_overwatch/services/aggregators/test_portfolio_aggregator.py
@@ -1,22 +1,89 @@
-def test_get_portoflio():
-    pass
+from stonks_overwatch.services.aggregators.portfolio_aggregator import PortfolioAggregatorService
+from stonks_overwatch.services.models import PortfolioEntry
+from stonks_overwatch.utils.domain.constants import ProductType
+
+import pytest
+from unittest.mock import MagicMock, patch
 
 
-def test_get_portfolio_only_degiro():
-    pass
+@pytest.fixture
+def aggregator():
+    with patch("stonks_overwatch.services.aggregators.portfolio_aggregator.YFinance") as mock_yf_class:
+        mock_yf = MagicMock()
+        mock_yf_class.return_value = mock_yf
+        svc = PortfolioAggregatorService()
+        svc.yfinance = mock_yf
+        yield svc, mock_yf
 
 
-def test_get_portfolio_only_bitvavo():
-    pass
+class TestAssignName:
+    """Tests for PortfolioAggregatorService._assign_name()."""
 
+    def test_resolves_name_when_name_equals_symbol(self, aggregator):
+        """Name is replaced with the full company name when it currently matches the ticker."""
+        svc, mock_yf = aggregator
+        mock_yf.get_name.return_value = "Apple Inc."
+        entry = PortfolioEntry(symbol="AAPL", name="AAPL", product_type=ProductType.STOCK)
 
-def test_calculate_historical_value():
-    pass
+        svc._assign_name(entry)
 
+        assert entry.name == "Apple Inc."
+        mock_yf.get_name.assert_called_once_with("AAPL")
 
-def test_calculate_historical_value_only_degiro():
-    pass
+    def test_resolves_name_when_name_is_empty(self, aggregator):
+        """Name is filled in when the broker left it blank."""
+        svc, mock_yf = aggregator
+        mock_yf.get_name.return_value = "Tesla Inc."
+        entry = PortfolioEntry(symbol="TSLA", name="", product_type=ProductType.STOCK)
 
+        svc._assign_name(entry)
 
-def test_calculate_historical_value_only_bitvavo():
-    pass
+        assert entry.name == "Tesla Inc."
+
+    def test_does_not_overwrite_existing_name(self, aggregator):
+        """A name already set by the broker (e.g. DEGIRO) is not replaced."""
+        svc, mock_yf = aggregator
+        entry = PortfolioEntry(symbol="AAPL", name="Apple Inc.", product_type=ProductType.STOCK)
+
+        svc._assign_name(entry)
+
+        assert entry.name == "Apple Inc."
+        mock_yf.get_name.assert_not_called()
+
+    def test_skips_cash_entries(self, aggregator):
+        """Cash entries are never looked up in yfinance."""
+        svc, mock_yf = aggregator
+        entry = PortfolioEntry(symbol="USD", name="USD", product_type=ProductType.CASH)
+
+        svc._assign_name(entry)
+
+        mock_yf.get_name.assert_not_called()
+
+    def test_skips_crypto_entries(self, aggregator):
+        """Crypto entries are never looked up in yfinance."""
+        svc, mock_yf = aggregator
+        entry = PortfolioEntry(symbol="BTC", name="BTC", product_type=ProductType.CRYPTO)
+
+        svc._assign_name(entry)
+
+        mock_yf.get_name.assert_not_called()
+
+    def test_resolves_name_for_etf(self, aggregator):
+        """ETF entries are enriched the same as stocks."""
+        svc, mock_yf = aggregator
+        mock_yf.get_name.return_value = "iShares Core S&P 500 ETF"
+        entry = PortfolioEntry(symbol="IVV", name="IVV", product_type=ProductType.ETF)
+
+        svc._assign_name(entry)
+
+        assert entry.name == "iShares Core S&P 500 ETF"
+
+    def test_keeps_symbol_when_yfinance_returns_none(self, aggregator):
+        """If yfinance has no name, the existing value (ticker) is preserved."""
+        svc, mock_yf = aggregator
+        mock_yf.get_name.return_value = None
+        entry = PortfolioEntry(symbol="XYZ", name="XYZ", product_type=ProductType.STOCK)
+
+        svc._assign_name(entry)
+
+        assert entry.name == "XYZ"

--- a/tests/stonks_overwatch/services/brokers/yfinance/test_yfinance.py
+++ b/tests/stonks_overwatch/services/brokers/yfinance/test_yfinance.py
@@ -347,3 +347,50 @@ def test_rate_limit_respects_cached_data(yfinance_service, mock_yfinance_client,
     assert industry == "Consumer Electronics"
     # get_ticker should not be called since data was cached
     mock_yfinance_client.get_ticker.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get_name tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_name_returns_long_name(yfinance_service, mock_yfinance_repository):
+    """Test that get_name returns longName when available."""
+    mock_yfinance_repository.get_ticker_info.return_value = {
+        "longName": "Apple Inc.",
+        "shortName": "Apple",
+    }
+
+    result = yfinance_service.get_name("AAPL")
+
+    assert result == "Apple Inc."
+
+
+def test_get_name_falls_back_to_short_name(yfinance_service, mock_yfinance_repository):
+    """Test that get_name falls back to shortName when longName is absent."""
+    mock_yfinance_repository.get_ticker_info.return_value = {"shortName": "Apple"}
+
+    result = yfinance_service.get_name("AAPL")
+
+    assert result == "Apple"
+
+
+def test_get_name_returns_none_when_no_name_fields(yfinance_service, mock_yfinance_repository):
+    """Test that get_name returns None when neither name field is present."""
+    mock_yfinance_repository.get_ticker_info.return_value = {"sector": "Technology"}
+
+    result = yfinance_service.get_name("AAPL")
+
+    assert result is None
+
+
+def test_get_name_returns_none_when_ticker_info_unavailable(
+    yfinance_service, mock_yfinance_client, mock_yfinance_repository
+):
+    """Test that get_name returns None when ticker info cannot be fetched."""
+    mock_yfinance_repository.get_ticker_info.return_value = None
+    mock_yfinance_client.get_ticker.side_effect = Exception("Network error")
+
+    result = yfinance_service.get_name("UNKNOWN")
+
+    assert result is None


### PR DESCRIPTION
# Pull Request

## Description

Alpaca doesn't seem to provide the asset full name, only the ticker. Here we use YFinance to fix the problem.

Update CHANGELOG to have all the expected links

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactoring
- [ ] 🏦 Broker integration
- [ ] 🎨 UI/UX

## Testing & Quality

- [x] Tests pass (`make test`)
- [x] Code formatted (`make lint-fix`)
- [x] Documentation updated

---

✅ **Checklist:** Read [CONTRIBUTING](../CONTRIBUTING.md), tests pass, code formatted, docs updated

**Thank you for contributing!** 🎉
