### PR TITLE
fix: Handle None stock splits data in yfinance client

### DIFF
--- a/src/stonks_overwatch/services/brokers/yfinance/client/yfinance_client.py
+++ b/src/stonks_overwatch/services/brokers/yfinance/client/yfinance_client.py
@@ -69,5 +69,9 @@ class YFinanceClient:
             )
             return []
 
+        if splits is None:
+            self.logger.warning(f"No splits data available for {ticker_info.ticker}. Returning empty splits list.")
+            return []
+
         splits_list = [StockSplit(date.to_pydatetime().astimezone(), ratio) for date, ratio in splits.to_dict().items()]
         return splits_list

--- a/tests/stonks_overwatch/services/brokers/yfinance/test_yfinance.py
+++ b/tests/stonks_overwatch/services/brokers/yfinance/test_yfinance.py
@@ -394,3 +394,17 @@ def test_get_name_returns_none_when_ticker_info_unavailable(
     result = yfinance_service.get_name("UNKNOWN")
 
     assert result is None
+
+
+def test_client_get_stock_splits_returns_empty_when_splits_is_none():
+    """Test that the client handles None splits data without crashing."""
+    from stonks_overwatch.services.brokers.yfinance.client.yfinance_client import YFinanceClient
+
+    client = YFinanceClient()
+    mock_ticker = MagicMock()
+    mock_ticker.ticker = "AAPL"
+    mock_ticker.splits = None
+
+    result = client.get_stock_splits(mock_ticker)
+
+    assert result == []


### PR DESCRIPTION
# Pull Request

## Description

yfinance's Ticker.splits can return None when no splits data is available, causing a 'NoneType' object has no attribute 'to_dict' crash during demo-mode dashboard rendering. Guard against None and return an empty splits list, with a regression test.

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactoring
- [ ] 🏦 Broker integration
- [ ] 🎨 UI/UX

---

✅ **Checklist:** Read [CONTRIBUTING](../CONTRIBUTING.md), tests pass, code formatted, docs updated

**Thank you for contributing!** 🎉
